### PR TITLE
resigns_tasks_upon_quit test fix

### DIFF
--- a/src/test/resources/com/zerocracy/bundles/resigns_tasks_upon_quit/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/resigns_tasks_upon_quit/_after.groovy
@@ -18,13 +18,13 @@ package com.zerocracy.bundles.resigns_tasks_upon_quit
 
 import com.jcabi.xml.XML
 import com.zerocracy.Project
+import com.zerocracy.pm.in.Orders
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
 
 def exec(Project project, XML xml) {
-// @todo #235:30min This test started to fail after `remove_assignee`
-//  script fix. In this test stakeholder can't find assignee in MkIssue
-//  which throws an exception: XPath
-//  '/github/repos/repo[@coords='test/test']/issues/issue[number='2']' not found
-
-//  Orders orders = new Orders(project).bootstrap()
-//  assert orders.jobs('cmiranda').empty
+  MatcherAssert.assertThat(
+    new Orders(project).bootstrap().jobs('cmiranda'),
+    Matchers.emptyIterable()
+  )
 }

--- a/src/test/resources/com/zerocracy/bundles/resigns_tasks_upon_quit/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/resigns_tasks_upon_quit/_before.groovy
@@ -23,6 +23,7 @@ import com.zerocracy.entry.ExtGithub
 import com.zerocracy.Farm
 import com.zerocracy.Project
 import com.zerocracy.pm.ClaimOut
+import com.zerocracy.pmo.Pmo
 
 def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
@@ -36,5 +37,5 @@ def exec(Project project, XML xml) {
     .token("job;gh:${repo.coordinates()}#${issue.number()}")
     .author('cmiranda')
     .param('project', project.pid())
-    .postTo(project)
+    .postTo(new Pmo(farm))
 }


### PR DESCRIPTION
#281 - `resigns_tasks_upon_quit` test fix; using `PMO` instead of `project`.