### PR TITLE
Cancellation reason in Github comments

### DIFF
--- a/src/main/resources/com/zerocracy/stk/pm/in/orders/cancel_order.groovy
+++ b/src/main/resources/com/zerocracy/stk/pm/in/orders/cancel_order.groovy
@@ -43,10 +43,16 @@ def exec(Project project, XML xml) {
     )
   }
   orders.resign(job)
+  String reason
+  if (claim.hasParam('reason')) {
+    reason = claim.param('reason')
+  } else {
+    reason = 'Order was cancelled'
+  }
   claim.reply(
     new Par(
-      'The user @%s resigned from %s, please stop working',
-    ).say(performer, job)
+      'The user @%s resigned from %s, please stop working: %s',
+    ).say(performer, job, reason)
   ).postTo(project)
   claim.copy()
     .type('Order was canceled')

--- a/src/main/resources/com/zerocracy/stk/pm/in/orders/cancel_order.groovy
+++ b/src/main/resources/com/zerocracy/stk/pm/in/orders/cancel_order.groovy
@@ -51,7 +51,7 @@ def exec(Project project, XML xml) {
   }
   claim.reply(
     new Par(
-      'The user @%s resigned from %s, please stop working: %s',
+      'The user @%s resigned from %s, please stop working. Reason for job resignation: %s',
     ).say(performer, job, reason)
   ).postTo(project)
   claim.copy()

--- a/src/test/resources/com/zerocracy/bundles/cancel_order/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/cancel_order/_after.groovy
@@ -16,16 +16,15 @@
  */
 package com.zerocracy.bundles.cancel_order
 
-import com.jcabi.github.Coordinates
-import com.jcabi.github.Github
-import com.jcabi.github.Issue
-import com.jcabi.github.Repo
+import com.jcabi.github.*
 import com.jcabi.xml.XML
-import com.zerocracy.entry.ExtGithub
 import com.zerocracy.Farm
 import com.zerocracy.Project
+import com.zerocracy.entry.ExtGithub
 import com.zerocracy.pm.staff.Bans
 import com.zerocracy.pmo.Agenda
+import org.cactoos.collection.Mapped
+import org.cactoos.list.ListOf
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 
@@ -33,8 +32,9 @@ def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
   Github github = new ExtGithub(farm).value()
   Repo repo = github.repos().get(new Coordinates.Simple('test/test'))
+  Issue.Smart issue = new Issue.Smart(repo.issues().get(1))
   MatcherAssert.assertThat(
-    new Issue.Smart(repo.issues().get(1)).assignee().login(),
+    issue.assignee().login(),
     Matchers.equalTo('')
   )
   MatcherAssert.assertThat(
@@ -44,5 +44,12 @@ def exec(Project project, XML xml) {
   MatcherAssert.assertThat(
     new Bans(project).bootstrap().reasons('gh:test/test#1', 'g4s8'),
     Matchers.iterableWithSize(1)
+  )
+  MatcherAssert.assertThat(
+    new Mapped<>(
+      {new Comment.Smart(it as Comment).body() },
+      issue.comments().iterate(new Date(0))
+    ),
+    Matchers.hasItem(Matchers.stringContainsInOrder(new ListOf<String>('please stop working', 'Test reason')))
   )
 }

--- a/src/test/resources/com/zerocracy/bundles/cancel_order/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/cancel_order/claims.xml
@@ -33,6 +33,7 @@ SOFTWARE.
     <params>
       <param name="job">gh:test/test#1</param>
       <param name="login">g4s8</param>
+      <param name="reason">Test reason</param>
     </params>
   </claim>
   <claim id="4">


### PR DESCRIPTION
#499 - added `cancel_order` claim reason to Github comment message, the text for a reason is already defined, e.g. in `resign_on_delay`: "It is older than %d day(s), see §8".