### PR TITLE
#284 Removed outdated puzzle

### DIFF
--- a/src/test/java/com/zerocracy/tk/project/TkFootprintTest.java
+++ b/src/test/java/com/zerocracy/tk/project/TkFootprintTest.java
@@ -32,11 +32,6 @@ import org.takes.rs.RsPrint;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.13
- * @todo #155:30min This test and `FtParamTest` fail
- *  because they require proper 'mongod' installation.
- *  Locally test fails with error:
- *  "Cannot run program "mongod": error=2, No such file or directory",
- *  on Shippable it's 'MongoTimeoutException'.
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */


### PR DESCRIPTION
PR for #284 

The test in TkFootprintTest has been ``@Ignore``d in #155 (when the puzzle was created), but since then has been unignored, which means it's working.

I think ``FtParamTest`` was renamed to ``FtFarmTest``, which doesn't have any ``@Ignore``d tests either.

We are also not using Shippable anymore.