### PR TITLE
#489 read children in TkClaim + puzzle

### DIFF
--- a/src/main/java/com/zerocracy/tk/project/TkClaim.java
+++ b/src/main/java/com/zerocracy/tk/project/TkClaim.java
@@ -26,9 +26,10 @@ import com.zerocracy.tk.RsPage;
 import com.zerocracy.tk.RsParFlash;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.bson.Document;
 import org.cactoos.iterable.ItemAt;
 import org.cactoos.iterable.Mapped;
@@ -81,27 +82,23 @@ public final class TkClaim implements TkRegex {
         final String user = new RqUser(this.farm, request).value();
         final long cid = Long.valueOf(request.matcher().group(2));
         try (final Footprint ftp = new Footprint(this.farm, pkt)) {
-            final List<XeSource> children = new ArrayList<>(10);
-            for (
-                final Document child : ftp.collection().find(
-                    Filters.eq("cause", cid)
-                )
-            ) {
-                children.add(
-                    new XeChain(
-                        new XeAppend(
-                            "child",
-                            new XeTransform<>(
-                                child.entrySet(),
-                                ent -> new XeAppend(
-                                    ent.getKey(),
-                                    ent.getValue().toString()
-                                )
+            final List<XeSource> children = StreamSupport.stream(
+                ftp.collection().find(Filters.eq("cause", cid))
+                    .spliterator(), false
+            ).map(
+                document -> new XeChain(
+                    new XeAppend(
+                        "child",
+                        new XeTransform<>(
+                            document.entrySet(),
+                            ent -> new XeAppend(
+                                ent.getKey(),
+                                ent.getValue().toString()
                             )
                         )
                     )
-                );
-            }
+                )
+            ).collect(Collectors.toList());
             return new IoCheckedScalar<>(
                 new ItemAt<>(
                     0,

--- a/src/main/java/com/zerocracy/tk/project/TkClaim.java
+++ b/src/main/java/com/zerocracy/tk/project/TkClaim.java
@@ -26,6 +26,8 @@ import com.zerocracy.tk.RsPage;
 import com.zerocracy.tk.RsParFlash;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import org.bson.Document;
 import org.cactoos.iterable.ItemAt;
@@ -38,6 +40,7 @@ import org.takes.facets.forward.RsForward;
 import org.takes.rs.RsWithStatus;
 import org.takes.rs.xe.XeAppend;
 import org.takes.rs.xe.XeChain;
+import org.takes.rs.xe.XeSource;
 import org.takes.rs.xe.XeTransform;
 
 /**
@@ -47,8 +50,17 @@ import org.takes.rs.xe.XeTransform;
  * @version $Id$
  * @since 0.20
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @todo #489:30min Change claim.xsl in such a way that it displays the
+ *  children of this claim as well. They are returned in the children
+ *  element and represent all the claims that have the cause equal to this
+ *  claim's id.
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings(
+    {
+        "PMD.AvoidDuplicateLiterals",
+        "PMD.AvoidInstantiatingObjectsInLoops"
+    }
+)
 public final class TkClaim implements TkRegex {
     /**
      * A farm.
@@ -69,6 +81,27 @@ public final class TkClaim implements TkRegex {
         final String user = new RqUser(this.farm, request).value();
         final long cid = Long.valueOf(request.matcher().group(2));
         try (final Footprint ftp = new Footprint(this.farm, pkt)) {
+            final List<XeSource> children = new ArrayList<>(10);
+            for (
+                final Document child : ftp.collection().find(
+                    Filters.eq("cause", cid)
+                )
+            ) {
+                children.add(
+                    new XeChain(
+                        new XeAppend(
+                            "child",
+                            new XeTransform<>(
+                                child.entrySet(),
+                                ent -> new XeAppend(
+                                    ent.getKey(),
+                                    ent.getValue().toString()
+                                )
+                            )
+                        )
+                    )
+                );
+            }
             return new IoCheckedScalar<>(
                 new ItemAt<>(
                     0,
@@ -103,6 +136,10 @@ public final class TkClaim implements TkRegex {
                                                 ent.getValue().toString()
                                             )
                                         )
+                                    ),
+                                    new XeAppend(
+                                        "children",
+                                        new XeChain(() -> children)
                                     )
                                 );
                             }

--- a/src/test/java/com/zerocracy/tk/project/TkClaimTest.java
+++ b/src/test/java/com/zerocracy/tk/project/TkClaimTest.java
@@ -37,7 +37,8 @@ import org.takes.rs.RsPrint;
  * @version $Id$
  * @since 0.20
  * @todo #489:30min Write more test cases for a claim's children.
- *  Currently only the no-children case is validated.
+ *  Currently only the no-children case is validated, tests for one
+ *  and for more children are required.
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/com/zerocracy/tk/project/TkClaimTest.java
+++ b/src/test/java/com/zerocracy/tk/project/TkClaimTest.java
@@ -38,10 +38,13 @@ import org.takes.rs.RsPrint;
  * @since 0.20
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @todo #489:30min Write more test cases for a claim's children.
+ *  Currently only the no-children case is validated.
  */
 public final class TkClaimTest {
+
     @Test
-    public void renderClaimXml() throws Exception {
+    public void renderClaimWithNoChildrenXml() throws Exception {
         final Farm farm = new FtFarm(new PropsFarm(new FkFarm()));
         final long cid = 42L;
         final ClaimOut claim = new ClaimOut().type("test").cid(cid);
@@ -66,8 +69,10 @@ public final class TkClaimTest {
                 ).printBody()
             ),
             XhtmlMatchers.hasXPaths(
-                String.format("/page/claim/cid[text() = %d]", cid)
+                String.format("/page/claim/cid[text() = %d]", cid),
+                String.format("/page/children")
             )
         );
     }
+
 }

--- a/src/test/java/com/zerocracy/tk/project/TkClaimTest.java
+++ b/src/test/java/com/zerocracy/tk/project/TkClaimTest.java
@@ -36,10 +36,10 @@ import org.takes.rs.RsPrint;
  * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.20
- * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @todo #489:30min Write more test cases for a claim's children.
  *  Currently only the no-children case is validated.
+ * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class TkClaimTest {
 


### PR DESCRIPTION
Pr for #489 

Inside TkClaim its children are also read from the Footprint (the Claims which have the ``cause`` element equal to this claim's id).

Left a puzzle for editing ``claim.xsl`` in such a way that its children are also displayed.