### PR TITLE
#425 Fixed possible memory leak

### DIFF
--- a/src/main/java/com/zerocracy/radars/slack/TkSlack.java
+++ b/src/main/java/com/zerocracy/radars/slack/TkSlack.java
@@ -57,6 +57,11 @@ public final class TkSlack implements Take {
     private final SlackRadar radar;
 
     /**
+     * Refresh the SlackRadar asynchronously.
+     */
+    private final AsyncFunc<Boolean, Boolean> refresh;
+
+    /**
      * Ctor.
      * @param frm Farm
      * @param rdr Radar
@@ -64,6 +69,12 @@ public final class TkSlack implements Take {
     public TkSlack(final Farm frm, final SlackRadar rdr) {
         this.farm = frm;
         this.radar = rdr;
+        this.refresh = new AsyncFunc<Boolean, Boolean>(
+            input -> {
+                this.radar.refresh();
+            },
+            new VerboseThreads()
+        );
     }
 
     @Override
@@ -105,12 +116,7 @@ public final class TkSlack implements Take {
         }
         final Bots bots = new Bots(this.farm).bootstrap();
         final String team = bots.register(json);
-        new AsyncFunc<Boolean, Boolean>(
-            input -> {
-                this.radar.refresh();
-            },
-            new VerboseThreads()
-        ).apply(true);
+        this.refresh.apply(true);
         return new RsWithStatus(
             new RsWithHeader(
                 "Location",

--- a/src/main/java/com/zerocracy/radars/slack/TkSlack.java
+++ b/src/main/java/com/zerocracy/radars/slack/TkSlack.java
@@ -52,11 +52,6 @@ public final class TkSlack implements Take {
     private final Farm farm;
 
     /**
-     * Radar.
-     */
-    private final SlackRadar radar;
-
-    /**
      * Refresh the SlackRadar asynchronously.
      */
     private final AsyncFunc<Boolean, Boolean> refresh;
@@ -68,10 +63,9 @@ public final class TkSlack implements Take {
      */
     public TkSlack(final Farm frm, final SlackRadar rdr) {
         this.farm = frm;
-        this.radar = rdr;
         this.refresh = new AsyncFunc<Boolean, Boolean>(
             input -> {
-                this.radar.refresh();
+                rdr.refresh();
             },
             new VerboseThreads()
         );

--- a/src/main/java/com/zerocracy/tk/TkDump.java
+++ b/src/main/java/com/zerocracy/tk/TkDump.java
@@ -35,10 +35,8 @@ import org.takes.rs.RsWithType;
  * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.20
- * @todo #360:30min Download and analyze heap dump from https://www.0crat.com/heapdump
- *  after next out of memory error,
- *  then fix memory leaks
- *  and remove this debug class.
+ * @todo #425:30min Download and analyze heap dump from https://www.0crat.com/heapdump
+ *  after next out of memory error, then fix memory leaks.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class TkDump implements Take {

--- a/src/main/java/com/zerocracy/tk/TkDump.java
+++ b/src/main/java/com/zerocracy/tk/TkDump.java
@@ -35,8 +35,9 @@ import org.takes.rs.RsWithType;
  * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.20
- * @todo #425:30min Download and analyze heap dump from https://www.0crat.com/heapdump
- *  after next out of memory error, then fix memory leaks.
+ * @todo #425:30min Download and analyze heap dump from
+ *  https://www.0crat.com/heapdump after next out of memory error,
+ *  then fix detected memory leaks. Also waiting for #400 to be solved.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class TkDump implements Take {


### PR DESCRIPTION
PR for #425 
SInce the dump cannot be downloaded yet (waiting for #400, apparently) and since it's not ok to just wait indefinetely, I did another improvement: 

TkSlack would create an ``AsyncFunc`` to refresh Slack asynchronously, but the reference was not assigned, thus that ``AsyncFunc`` would become an "island object", trouble for the gc. Add to that the fact that it starts one of more different threads inside, it was probably a memory leak point. So, AsyncFunc is now an attribute of TkSlack. 