### PR TITLE
#229 assign_role fails if user is not on Github

### DIFF
--- a/src/main/resources/com/zerocracy/stk/pm/staff/roles/assign_role.groovy
+++ b/src/main/resources/com/zerocracy/stk/pm/staff/roles/assign_role.groovy
@@ -64,9 +64,9 @@ def exec(Project project, XML xml) {
   } else {
     roles.assign(login, role)
     msg = new Par(
-      'Role %s was successfully assigned to @%s (%s followers),',
+      'Role %s was successfully assigned to @%s,',
       'see [full list](/a/%s?a=pm/staff/roles) of roles. '
-    ).say(role, login, user.followersCount(), project.pid())
+    ).say(role, login, project.pid())
     claim.copy()
       .type('Role was assigned')
       .param('role', role)


### PR DESCRIPTION
Pr for #229 

The code is rather ugly and it cannot easily be tested because MkUser does not behave the same as RtUser -- MkUser.json() simply returns ``{login: username}`` for any login input. In order to properly test this scenario, we would need another mock implementation of User, decorate the test Github instance somehow (its Users, to be more precise, they should return another version of MkUser). 

Furthermore, the user ``Github`` instance is wraped inside ``ExtGithub`` scalar and cannot be changed at all -- that class should be refactored.