### PR TITLE
Removed useless regex check

### DIFF
--- a/src/main/java/com/zerocracy/radars/github/ReIfAddressed.java
+++ b/src/main/java/com/zerocracy/radars/github/ReIfAddressed.java
@@ -21,7 +21,6 @@ import com.zerocracy.Farm;
 import com.zerocracy.Par;
 import com.zerocracy.SoftException;
 import java.io.IOException;
-import java.util.regex.Pattern;
 
 /**
  * Response if not my comment.
@@ -51,33 +50,22 @@ public final class ReIfAddressed implements Response {
         final String self = String.format(
             "@%s", comment.issue().repo().github().users().self().login()
         );
-        boolean done = false;
-        if (comment.body().contains(self)) {
-            final Pattern pattern = Pattern.compile(
-                String.format(
-                    "\\s*@%s\\s*.+",
-                    comment.issue().repo().github().users().self().login()
-                ),
-                Pattern.MULTILINE | Pattern.CASE_INSENSITIVE
+        if (!comment.body().trim().startsWith(self)) {
+            throw new SoftException(
+                new Par(
+                    "Are you speaking to me or about me",
+                    String.format(
+                        // @checkstyle LineLength (1 line)
+                        "[here](https://github.com/%s/issues/%d#issuecomment-%d).",
+                        comment.issue().repo().coordinates(),
+                        comment.issue().number(), comment.number()
+                    ),
+                    "You must always start your message with my name",
+                    "if you want to address it to me, see §1."
+                ).say()
             );
-            if (!pattern.matcher(comment.body()).matches()) {
-                throw new SoftException(
-                    new Par(
-                        "Are you speaking to me or about me",
-                        String.format(
-                            // @checkstyle LineLength (1 line)
-                            "[here](https://github.com/%s/issues/%d#issuecomment-%d).",
-                            comment.issue().repo().coordinates(),
-                            comment.issue().number(), comment.number()
-                        ),
-                        "You must always start your message with my name",
-                        "if you want to address it to me, see §1."
-                    ).say()
-                );
-            }
-            done = this.origin.react(farm, comment);
         }
-        return done;
+        return this.origin.react(farm, comment);
     }
 
 }

--- a/src/main/java/com/zerocracy/radars/github/ReIfAddressed.java
+++ b/src/main/java/com/zerocracy/radars/github/ReIfAddressed.java
@@ -48,9 +48,10 @@ public final class ReIfAddressed implements Response {
     public boolean react(final Farm farm, final Comment.Smart comment)
         throws IOException {
         final String self = String.format(
-            "@%s", comment.issue().repo().github().users().self().login()
+            "@%s ", comment.issue().repo().github().users().self().login()
         );
-        if (!comment.body().trim().startsWith(self)) {
+        final String body = comment.body().trim();
+        if (!body.startsWith(self) || body.equals(self)) {
             throw new SoftException(
                 new Par(
                     "Are you speaking to me or about me",

--- a/src/test/java/com/zerocracy/radars/github/ReIfAddressedTest.java
+++ b/src/test/java/com/zerocracy/radars/github/ReIfAddressedTest.java
@@ -111,7 +111,7 @@ public final class ReIfAddressedTest {
      * @throws IOException If something goes wrong.
      */
     @Test(expected = SoftException.class)
-    public void complainsAbouEmptyComment() throws IOException {
+    public void complainsAboutEmptyComment() throws IOException {
         final Comment.Smart initial = this.comment("@0crat  ");
         final Farm fake = new FkFarm();
         final ReIfAddressed ria = new ReIfAddressed(

--- a/src/test/java/com/zerocracy/radars/github/ReIfAddressedTest.java
+++ b/src/test/java/com/zerocracy/radars/github/ReIfAddressedTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.radars.github;
+
+import com.jcabi.github.Comment;
+import com.jcabi.github.Github;
+import com.jcabi.github.Issue;
+import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
+import com.jcabi.github.mock.MkGithub;
+import com.jcabi.github.mock.MkStorage;
+import com.zerocracy.Farm;
+import com.zerocracy.SoftException;
+import com.zerocracy.farm.fake.FkFarm;
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test case for {@link ReIfAddressed}.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.21.2
+ */
+public final class ReIfAddressedTest {
+
+    /**
+     * ReIfAddressed delegates the addressed comment to the encapsulated
+     * Response.
+     * @throws IOException If something goes wrong.
+     */
+    @Test
+    public void delegatesAddressedComment() throws IOException {
+        final Comment.Smart initial = this.comment("@0crat hello");
+        final Farm fake = new FkFarm();
+        final String response = "@jeff hello to you, too!";
+        final ReIfAddressed ria = new ReIfAddressed(
+            (farm, comment) -> {
+                MatcherAssert.assertThat(
+                    fake == farm, Matchers.is(Boolean.TRUE)
+                );
+                MatcherAssert.assertThat(
+                    comment.body(),
+                    Matchers.equalTo(initial.body())
+                );
+                comment.issue().comments().post(response);
+                return true;
+            }
+        );
+        ria.react(fake, initial);
+        MatcherAssert.assertThat(
+            "Initial comment was not responded to!",
+            new Comment.Smart(initial.issue().comments().get(2)).body(),
+            Matchers.equalTo(response)
+        );
+    }
+
+    /**
+     * ReIfAddressed throws a SoftException if the comment is not addressed.
+     * @throws IOException If something goes wrong.
+     */
+    @Test(expected = SoftException.class)
+    public void complainsAboutUnaddressedComment() throws IOException {
+        final Comment.Smart initial = this.comment("hello");
+        final Farm fake = new FkFarm();
+        final ReIfAddressed ria = new ReIfAddressed(
+            (farm, comment) -> {
+                Assert.fail("SoftException expected");
+                return true;
+            }
+        );
+        ria.react(fake, initial);
+    }
+
+    /**
+     * Mock a Comment for test. Jeff leaves a comment, then 0crat
+     * logs in and reads it.
+     * @param body The comment's body.
+     * @return Github comment received by 0crat.
+     * @throws IOException If something goes wrong.
+     */
+    private Comment.Smart comment(final String body) throws IOException {
+        final MkStorage server = new MkStorage.InFile();
+        final Github jeff = new MkGithub(server,  "jeff");
+        final Repo repo = jeff.repos().create(
+            new Repos.RepoCreate("test", false)
+        );
+        final Issue issue = new Issue.Smart(
+            repo.issues().create("first title", "")
+        );
+        final Comment.Smart initial = new Comment.Smart(
+            issue.comments().post(body)
+        );
+        return new Comment.Smart(
+            new MkGithub(server,  "0crat")
+                .repos().get(repo.coordinates())
+                .issues().get(issue.number())
+                .comments().get(initial.number())
+        );
+    }
+
+}

--- a/src/test/java/com/zerocracy/radars/github/ReIfAddressedTest.java
+++ b/src/test/java/com/zerocracy/radars/github/ReIfAddressedTest.java
@@ -89,6 +89,41 @@ public final class ReIfAddressedTest {
     }
 
     /**
+     * ReIfAddressed throws a SoftException if the comment is misaddressed.
+     * @throws IOException If something goes wrong.
+     */
+    @Test(expected = SoftException.class)
+    public void complainsAboutMisaddressedComment() throws IOException {
+        final Comment.Smart initial = this.comment("@0crat-test hello");
+        final Farm fake = new FkFarm();
+        final ReIfAddressed ria = new ReIfAddressed(
+            (farm, comment) -> {
+                Assert.fail("SoftException expected here");
+                return true;
+            }
+        );
+        ria.react(fake, initial);
+    }
+
+    /**
+     * ReIfAddressed throws a SoftException if the comment is addressed but
+     * containing no other text.
+     * @throws IOException If something goes wrong.
+     */
+    @Test(expected = SoftException.class)
+    public void complainsAbouEmptyComment() throws IOException {
+        final Comment.Smart initial = this.comment("@0crat  ");
+        final Farm fake = new FkFarm();
+        final ReIfAddressed ria = new ReIfAddressed(
+            (farm, comment) -> {
+                Assert.fail("SoftException was expected");
+                return true;
+            }
+        );
+        ria.react(fake, initial);
+    }
+
+    /**
      * Mock a Comment for test. Jeff leaves a comment, then 0crat
      * logs in and reads it.
      * @param body The comment's body.


### PR DESCRIPTION
PR for https://github.com/zerocracy/datum/issues/260

``ReIfAddressed``'s purpose is to check if the Github comment starts with 0crat's handle (``@0crat``). However, instead of simply checking ``comment.trim().startsWith(self)``, it checks for ``contains`` and tries to match some regex with single line/multiline...? That regex has no purpose since it doesn't apply any change to the comment, one that maybe would benefit the next ``Response``. 


I removed the ``contains`` + regex matching and simply used ``startsWith``. The exception message already says "You must always start your message with my name" -- also ``ReQuestion`` (the encapsulated Response, to which the Comment is passed on) tries to parse the body as if it starts with the handle. 