### PR TITLE
0crat iz verbose, when invited to channel

### DIFF
--- a/src/main/java/com/zerocracy/radars/slack/ReInvite.java
+++ b/src/main/java/com/zerocracy/radars/slack/ReInvite.java
@@ -33,8 +33,6 @@ final class ReInvite implements Reaction<SlackChannelJoined> {
     @Override
     public boolean react(final Farm farm, final SlackChannelJoined event,
         final SlackSession session) throws IOException {
-        session.disconnect();
-        session.connect();
         session.sendMessage(
             event.getSlackChannel(),
             "Thanks for inviting me here."


### PR DESCRIPTION
Possible fix for [this issue](https://github.com/zerocracy/datum/issues/163)

I feel like there is no so much sense on disconnecting and then connecting again, since connect should already happen (as otherwise we don't receive this event). I think that it might be the possible cause for the issue, as on the new connection this event wasn't yet addressed and thus we get it again and again until the refresh is happen. Let's see if this will fix the issue. If not I will continue investigation.

Then the most probable reason might be the fact that simple-slack-api library has some bug and it is keeping sending the event.
