### PR TITLE
#422 Display title in Agenda started

### DIFF
--- a/src/main/java/com/zerocracy/pmo/Agenda.java
+++ b/src/main/java/com/zerocracy/pmo/Agenda.java
@@ -33,6 +33,9 @@ import org.xembly.Directives;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.12
+ * @todo #422:30min Modify agenda.xsd zerocracy/datum and make the element
+ *  order accept title as an attribute (same as job). Then, in method add(...)
+ *  from this class, make sure to specify the title as .attr("title", title).
  */
 public final class Agenda {
 
@@ -127,7 +130,6 @@ public final class Agenda {
                     .xpath("/agenda")
                     .add("order")
                     .attr("job", job)
-                    .attr("title", title)
                     .add("role").set(role).up()
                     .add("added").set(new DateAsText().asString()).up()
                     .add("project")

--- a/src/main/java/com/zerocracy/pmo/Agenda.java
+++ b/src/main/java/com/zerocracy/pmo/Agenda.java
@@ -107,10 +107,13 @@ public final class Agenda {
     /**
      * Add an order to the agenda.
      * @param job Job ID
+     * @param title Job title
      * @param role The role
      * @throws IOException If fails
      */
-    public void add(final String job, final String role) throws IOException {
+    public void add(
+        final String job, final String title, final String role
+    ) throws IOException {
         if (this.exists(job)) {
             throw new SoftException(
                 new Par(
@@ -124,6 +127,7 @@ public final class Agenda {
                     .xpath("/agenda")
                     .add("order")
                     .attr("job", job)
+                    .attr("title", title)
                     .add("role").set(role).up()
                     .add("added").set(new DateAsText().asString()).up()
                     .add("project")

--- a/src/main/java/com/zerocracy/pmo/Agenda.java
+++ b/src/main/java/com/zerocracy/pmo/Agenda.java
@@ -36,6 +36,8 @@ import org.xembly.Directives;
  * @todo #422:30min Modify agenda.xsd zerocracy/datum and make the element
  *  order accept title as an attribute (same as job). Then, in method add(...)
  *  from this class, make sure to specify the title as .attr("title", title).
+ *  Afterwards, the title has be displayed on the Agenda page (agenda.xsl
+ *  has to be modified).
  */
 public final class Agenda {
 

--- a/src/main/java/com/zerocracy/tk/profile/TkAgenda.java
+++ b/src/main/java/com/zerocracy/tk/profile/TkAgenda.java
@@ -34,6 +34,8 @@ import org.takes.facets.fork.TkRegex;
  * @todo #422:30min Display the title of the order on the Agenda page.
  *  The Issue's title is read from Github in add_to_agenda.groovy and
  *  in the agenda, it is an attribute of element order, same as its id (job).
+ *  This has as impediment the modification of agenda.xsd to accept the
+ *  title (see puzzle in Agenda.java, line 36.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class TkAgenda implements TkRegex {

--- a/src/main/java/com/zerocracy/tk/profile/TkAgenda.java
+++ b/src/main/java/com/zerocracy/tk/profile/TkAgenda.java
@@ -31,11 +31,6 @@ import org.takes.facets.fork.TkRegex;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.12
- * @todo #422:30min Display the title of the order on the Agenda page.
- *  The Issue's title is read from Github in add_to_agenda.groovy and
- *  in the agenda, it is an attribute of element order, same as its id (job).
- *  This has as impediment the modification of agenda.xsd to accept the
- *  title (see puzzle in Agenda.java, line 36.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class TkAgenda implements TkRegex {

--- a/src/main/java/com/zerocracy/tk/profile/TkAgenda.java
+++ b/src/main/java/com/zerocracy/tk/profile/TkAgenda.java
@@ -31,6 +31,9 @@ import org.takes.facets.fork.TkRegex;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.12
+ * @todo #422:30min Display the title of the order on the Agenda page.
+ *  The Issue's title is read from Github in add_to_agenda.groovy and
+ *  in the agenda, it is an attribute of element order, same as its id (job).
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class TkAgenda implements TkRegex {

--- a/src/main/resources/com/zerocracy/stk/pmo/agenda/add_to_agenda.groovy
+++ b/src/main/resources/com/zerocracy/stk/pmo/agenda/add_to_agenda.groovy
@@ -16,15 +16,18 @@
  */
 package com.zerocracy.stk.pmo.agenda
 
+import com.jcabi.github.Issue
 import com.jcabi.xml.XML
 import com.zerocracy.Farm
 import com.zerocracy.Project
+import com.zerocracy.entry.ExtGithub
 import com.zerocracy.farm.Assume
 import com.zerocracy.pm.ClaimIn
 import com.zerocracy.pm.cost.Estimates
 import com.zerocracy.pm.in.Orders
 import com.zerocracy.pm.scope.Wbs
 import com.zerocracy.pmo.Agenda
+import com.zerocracy.radars.github.Job
 
 def exec(Project project, XML xml) {
   new Assume(project, xml).notPmo()
@@ -38,8 +41,11 @@ def exec(Project project, XML xml) {
   String owner = orders.performer(job)
   String role = new Wbs(project).bootstrap().role(job)
   Farm farm = binding.variables.farm
+  Issue.Smart issue = new Issue.Smart(
+    new Job.Issue(new ExtGithub(farm).value(), job)
+  )
   Agenda agenda = new Agenda(farm, owner).bootstrap()
-  agenda.add(job, role)
+  agenda.add(job, issue.title(), role)
   Estimates estimates = new Estimates(project).bootstrap()
   if (estimates.exists(job)) {
     agenda.estimate(job, estimates.get(job))

--- a/src/test/java/com/zerocracy/farm/S3ProjectTest.java
+++ b/src/test/java/com/zerocracy/farm/S3ProjectTest.java
@@ -48,7 +48,7 @@ public final class S3ProjectTest {
         final String person = "yegor256";
         new Agenda(project, person).bootstrap();
         final String job = "gh:test/test#1";
-        new Agenda(project, person).add(job, "QA");
+        new Agenda(project, person).add(job, "Test", "QA");
         MatcherAssert.assertThat(
             new Agenda(project, person).jobs(),
             Matchers.hasItem(job)

--- a/src/test/java/com/zerocracy/pm/staff/votes/VsNoRoomTest.java
+++ b/src/test/java/com/zerocracy/pm/staff/votes/VsNoRoomTest.java
@@ -43,7 +43,7 @@ public final class VsNoRoomTest {
         final Agenda agenda = new Agenda(project, user).bootstrap();
         final int total = 10;
         for (int num = 1; num < total; ++num) {
-            agenda.add(String.format("gh:test/test#%d", num), "QA");
+            agenda.add(String.format("gh:test/test#%d", num), "Test", "QA");
         }
         MatcherAssert.assertThat(
             new VsNoRoom(project).take(user, new StringBuilder(0)),

--- a/src/test/java/com/zerocracy/pmo/AgendaTest.java
+++ b/src/test/java/com/zerocracy/pmo/AgendaTest.java
@@ -34,9 +34,9 @@ public final class AgendaTest {
     public void addsAndRemovesAgenda() throws Exception {
         final Agenda agenda = new Agenda(new FkProject(), "yegor").bootstrap();
         final String first = "gh:test/test#1";
-        agenda.add(first, "REV");
+        agenda.add(first, "Test", "REV");
         final String second = "gh:test/test#2";
-        agenda.add(second, "QA");
+        agenda.add(second, "Test2", "QA");
         agenda.remove(first);
         MatcherAssert.assertThat(agenda.jobs(), Matchers.hasItem(second));
     }

--- a/src/test/java/com/zerocracy/tk/profile/TkProfileTest.java
+++ b/src/test/java/com/zerocracy/tk/profile/TkProfileTest.java
@@ -44,7 +44,7 @@ public final class TkProfileTest {
         final Farm farm = new PropsFarm(new FkFarm());
         final String uid = "yegor256";
         new Awards(farm, uid).bootstrap().add(1, "gh:test/test#1", "reason");
-        new Agenda(farm, uid).bootstrap().add("gh:test/test#2", "QA");
+        new Agenda(farm, uid).bootstrap().add("gh:test/test#2", "Title", "QA");
         MatcherAssert.assertThat(
             XhtmlMatchers.xhtml(
                 new RsPrint(

--- a/src/test/resources/com/zerocracy/bundles/cancel_order/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/cancel_order/_before.groovy
@@ -30,9 +30,9 @@ def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
   Github github = new ExtGithub(farm).value()
   Repo repo = github.repos().create(new Repos.RepoCreate('test', false))
-  Issue issue = repo.issues().create('Test', '')
-  new Issue.Smart(issue).assign('g4s8')
+  Issue.Smart issue = new Issue.Smart(repo.issues().create('Test', ''))
+  issue.assign('g4s8')
   new Agenda(farm, 'g4s8').bootstrap().add(
-    "gh:${repo.coordinates()}#${issue.number()}", 'QA'
+    "gh:${repo.coordinates()}#${issue.number()}", issue.title(), 'QA'
   )
 }

--- a/src/test/resources/com/zerocracy/bundles/delete_stale_jobs/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/delete_stale_jobs/_before.groovy
@@ -28,5 +28,5 @@ def exec(Project project, XML xml) {
   new ExtGithub(farm).value().repos()
     .create(new Repos.RepoCreate('test', false))
     .issues().create('hello', 'world')
-  new Agenda(farm, 'g4s8').bootstrap().add('gh:test/test#1', 'DEV')
+  new Agenda(farm, 'g4s8').bootstrap().add('gh:test/test#1', 'hello', 'DEV')
 }


### PR DESCRIPTION
For #422 add_to_agenda.groovy now adds the title as well.

Modified the calls to Agenda.add(...) to also pass the title.

Could not yet add the title to the XML, inside Agenda.add(...), because the xsd validation fails.

Left puzzle to modify ``agenda.xsd`` from ``zerocracy/datum`` and to display the title on the Agenda page.