### PR TITLE
#415 skipBundlesTest option

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ the list of claims to be dispatched. There are also a few supplementary files:
 
 More details you can find in the Javadoc section of `BundlesTest`.
 
+You can skip BundlesTest's execution by specifying ``-DskipBundlesTest``:
+
+``$mvn clean install -Pqulice -DskipBundlesTest``
+
 ## Radars
 
 There are a number of entry points, where users can communicate with our

--- a/src/test/java/com/zerocracy/BundlesTest.java
+++ b/src/test/java/com/zerocracy/BundlesTest.java
@@ -129,9 +129,10 @@ public final class BundlesTest {
 
     @BeforeClass
     public static void checkShouldRun() {
-        Assume.assumeTrue(
+        Assume.assumeThat(
             "Parameter skipBundlesTest found, skipping...",
-            System.getProperty("skipBundlesTest") == null
+            System.getProperty("skipBundlesTest"),
+            Matchers.nullValue()
         );
     }
 

--- a/src/test/java/com/zerocracy/BundlesTest.java
+++ b/src/test/java/com/zerocracy/BundlesTest.java
@@ -59,7 +59,9 @@ import org.cactoos.text.JoinedText;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Assume;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -124,6 +126,14 @@ public final class BundlesTest {
     private String name;
 
     private Path home;
+
+    @BeforeClass
+    public static void maybeSkipThem() {
+        Assume.assumeTrue(
+            "Parameter skipBundlesTest found, skipping...",
+            System.getProperty("skipBundlesTest") == null
+        );
+    }
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> bundles() {

--- a/src/test/java/com/zerocracy/BundlesTest.java
+++ b/src/test/java/com/zerocracy/BundlesTest.java
@@ -128,7 +128,7 @@ public final class BundlesTest {
     private Path home;
 
     @BeforeClass
-    public static void maybeSkipThem() {
+    public static void checkShouldRun() {
         Assume.assumeTrue(
             "Parameter skipBundlesTest found, skipping...",
             System.getProperty("skipBundlesTest") == null


### PR DESCRIPTION
PR for #415 

Tested in IntelliJ: ``Run->Edit Configurations->VM Options``: ``-DskipBundlesTest``

Tested in terminal: 
- ``mvn clean install`` -> 1m 30s
- ``mvn clean install -DskipBundlesTest`` -> 40s

