### PR TITLE
#497 Agenda.removeAll() on destroy

### DIFF
--- a/src/main/java/com/zerocracy/pmo/Agenda.java
+++ b/src/main/java/com/zerocracy/pmo/Agenda.java
@@ -29,7 +29,8 @@ import org.cactoos.time.DateAsText;
 import org.xembly.Directives;
 
 /**
- * Agenda of one person.
+ * Agenda of one person in one Project, tasks that
+ * are assigned to them in that Project.
  *
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
@@ -151,6 +152,20 @@ public final class Agenda {
                 new Directives()
                     .xpath(String.format("/agenda/order[@job='%s']", job))
                     .strict(1)
+                    .remove()
+            );
+        }
+    }
+
+    /**
+     * Remove all orders.
+     * @throws IOException If fails.
+     */
+    public void removeAll() throws IOException {
+        try (final Item item = this.item()) {
+            new Xocument(item.path()).modify(
+                new Directives()
+                    .xpath("/agenda/order")
                     .remove()
             );
         }

--- a/src/main/resources/com/zerocracy/stk/pm/destroy.groovy
+++ b/src/main/resources/com/zerocracy/stk/pm/destroy.groovy
@@ -25,6 +25,7 @@ import com.zerocracy.Farm
 import com.zerocracy.Project
 import com.zerocracy.pm.ClaimIn
 import com.zerocracy.pm.staff.Roles
+import com.zerocracy.pmo.Agenda
 import com.zerocracy.pmo.Catalog
 import com.zerocracy.pmo.Projects
 
@@ -35,6 +36,7 @@ def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
   for (String login : new Roles(project).everybody()) {
     new Projects(farm, login).remove(project.pid())
+    new Agenda(project, login).removeAll()
   }
   Catalog catalog = new Catalog(farm).bootstrap()
   String prefix = catalog.findByXPath("@id='${project.pid()}'").iterator().next()

--- a/src/test/java/com/zerocracy/pmo/AgendaTest.java
+++ b/src/test/java/com/zerocracy/pmo/AgendaTest.java
@@ -41,4 +41,43 @@ public final class AgendaTest {
         MatcherAssert.assertThat(agenda.jobs(), Matchers.hasItem(second));
     }
 
+    /**
+     * Agenda can remove all the orders.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void removesAllOrders() throws Exception {
+        final Agenda agenda = new Agenda(new FkProject(), "mihai").bootstrap();
+        agenda.add("gh:test2/test#1", "REV1");
+        agenda.add("gh:test2/test#2", "QA1");
+        agenda.add("gh:test2/test#3", "DEV1");
+        MatcherAssert.assertThat(agenda.jobs(), Matchers.not(0));
+        agenda.removeAll();
+        MatcherAssert.assertThat(agenda.jobs(), Matchers.hasSize(0));
+    }
+
+    /**
+     * Agenda can remove the only order.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void removesSoleOrder() throws Exception {
+        final Agenda agenda = new Agenda(new FkProject(), "john").bootstrap();
+        agenda.add("gh:test3/test#1", "REV2");
+        MatcherAssert.assertThat(agenda.jobs(), Matchers.hasSize(1));
+        agenda.removeAll();
+        MatcherAssert.assertThat(agenda.jobs(), Matchers.hasSize(0));
+    }
+
+    /**
+     * Agenda can "remove" orders if it's empty.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void removesOrdersFromEmptyAgenda() throws Exception {
+        final Agenda agenda = new Agenda(new FkProject(), "jane").bootstrap();
+        MatcherAssert.assertThat(agenda.jobs(), Matchers.hasSize(0));
+        agenda.removeAll();
+        MatcherAssert.assertThat(agenda.jobs(), Matchers.hasSize(0));
+    }
 }


### PR DESCRIPTION
PR for #497

Added and tested method ``Agenda.removeAll(...)``. The alternative was to call ``Agenda.item()`` and run the xpath query inside ``destroy.groovy``, but I think it's better to keep XML classes out of the groovy scripts, let them be encapsulated. 