### PR TITLE
#728 Delete stale jobs from Agenda

### DIFF
--- a/src/main/resources/com/zerocracy/stk/pmo/agenda/delete_stale_jobs.groovy
+++ b/src/main/resources/com/zerocracy/stk/pmo/agenda/delete_stale_jobs.groovy
@@ -8,15 +8,14 @@ import com.zerocracy.pm.in.Orders
 import com.zerocracy.pmo.Agenda
 import com.zerocracy.pmo.People
 import com.zerocracy.pmo.Projects
+import org.cactoos.iterator.Shuffled
 
 def exec(Project pmo, XML xml) {
   new Assume(pmo, xml).isPmo()
   new Assume(pmo, xml).type('Ping hourly')
   ClaimIn claim = new ClaimIn(xml)
   People people = new People(pmo).bootstrap()
-  List<String> logins = new ArrayList<>(people.iterate().asList())
-  Collections.shuffle(logins)
-  logins.take(5).each { login ->
+  new Shuffled<>(people.iterate().iterator()).take(5).each { login ->
     Agenda agenda = new Agenda(pmo, login).bootstrap()
     Projects projects = new Projects(pmo, login).bootstrap()
     Set<String> orders = []

--- a/src/main/resources/com/zerocracy/stk/pmo/agenda/delete_stale_jobs.groovy
+++ b/src/main/resources/com/zerocracy/stk/pmo/agenda/delete_stale_jobs.groovy
@@ -16,7 +16,7 @@ def exec(Project pmo, XML xml) {
   People people = new People(pmo).bootstrap()
   List<String> logins = new ArrayList<>(people.iterate().asList())
   Collections.shuffle(logins)
-  logins.subList(0, Math.min(logins.size(), 5)).each { login ->
+  logins.take(5).each { login ->
     Agenda agenda = new Agenda(pmo, login).bootstrap()
     Projects projects = new Projects(pmo, login).bootstrap()
     Set<String> orders = []

--- a/src/test/resources/com/zerocracy/bundles/delete_stale_jobs/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/delete_stale_jobs/_after.groovy
@@ -17,13 +17,16 @@
 package com.zerocracy.bundles.delete_stale_jobs
 
 import com.jcabi.xml.XML
+import com.zerocracy.Farm
 import com.zerocracy.Project
+import com.zerocracy.pmo.Agenda
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
 
 def exec(Project project, XML xml) {
-//  Farm farm = binding.variables.farm
-//  Agenda agenda = new Agenda(farm, 'g4s8').bootstrap()
-//  MatcherAssert.assertThat(
-//    agenda.jobs(),
-//    Matchers.emptyIterable()
-//  )
+  Farm farm = binding.variables.farm
+  Agenda agenda = new Agenda(farm, 'g4s8').bootstrap()
+  MatcherAssert.assertThat(
+    agenda.jobs(), Matchers.empty()
+  )
 }

--- a/src/test/resources/com/zerocracy/bundles/delete_stale_jobs/_setup.xml
+++ b/src/test/resources/com/zerocracy/bundles/delete_stale_jobs/_setup.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
 Copyright (c) 2016-2018 Zerocracy
 
@@ -15,10 +15,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.27/xsd/pm/claims.xsd" version="0.1" updated="2017-03-27T11:18:09.228Z">
-  <claim id="1">
-    <type>Ping hourly</type>
-    <author>0crat</author>
-    <created>2017-01-15T01:00:00.000Z</created>
-  </claim>
-</claims>
+<setup>
+  <pmo>true</pmo>
+</setup>


### PR DESCRIPTION
#728: At "Ping hourly" event, take 5 random people. Go through each job in Agenda to check whether they correspond to existing orders in all of their projects. If there is no order remove the job from the Agenda.