### PR TITLE
#853 Explicit input redirect for Signature processes

### DIFF
--- a/src/main/java/com/zerocracy/tools/Signature.java
+++ b/src/main/java/com/zerocracy/tools/Signature.java
@@ -135,7 +135,7 @@ public final class Signature {
         builder.environment().putIfAbsent(
             "GNUPGHOME", System.getProperty("java.io.tmpdir")
         );
-        return builder;
+        return builder.redirectInput(ProcessBuilder.Redirect.PIPE);
     }
 
 }


### PR DESCRIPTION
#853: A brief explanation is in order.

The issue is very subtle. The stack trace of the original error shows us the following:

```
Caused by: java.io.IOException: Stream closed
        at java.lang.ProcessBuilder$NullOutputStream.write(ProcessBuilder.java:433)
        at java.io.OutputStream.write(OutputStream.java:116)
        at java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:82)
        at java.io.BufferedOutputStream.flush(BufferedOutputStream.java:140)
        at java.io.FilterOutputStream.close(FilterOutputStream.java:158)
        at org.cactoos.io.TeeInputStream.close(TeeInputStream.java:99)
        at org.cactoos.io.LengthOf.lambda$new$0(LengthOf.java:81)
        at org.cactoos.scalar.NumberEnvelope.lambda$new$1(NumberEnvelope.java:73)
        at org.cactoos.scalar.IoCheckedScalar.value(IoCheckedScalar.java:70)
        at org.cactoos.scalar.UncheckedScalar.value(UncheckedScalar.java:58)
```

The error message ("Stream closed") here is misleading. What's actually happening is that the Process has input redirection set and is returning a "[null output stream](https://docs.oracle.com/javase/8/docs/api/java/lang/ProcessBuilder.html#redirect-input)". This stream acts like it's closed, all the time, which causes this exception to be thrown. As for why the JDK programmers did not simply change the error message to something more useful, I've got as much of a clue as you do :unamused:.

So what we're doing now is ensuring that the input is always piped from the Java process (and thus available via `Process.getOutputStream()`). I am not sure why the error is intermittent - the default setting is `INHERIT` which causes the redirection setting to be inherited from the parent Java process, so somehow it's different under certain conditions.