### PR TITLE
#900 Redirect sign process input from file

### DIFF
--- a/src/main/java/com/zerocracy/tools/Signature.java
+++ b/src/main/java/com/zerocracy/tools/Signature.java
@@ -54,6 +54,7 @@ public final class Signature {
      * @return PGP signature
      * @throws IOException If fails
      */
+    @SuppressWarnings("PMD.PrematureDeclaration")
     public String asString() throws IOException {
         final String key = "0AAF4B5A";
         final Process receive = Signature.env(


### PR DESCRIPTION
#900: This is another attempt to fix `SignatureTest` which was started in #853.

The current fix attempts to address an apparent race condition, where the input of the "sign" process (via `sign.getOutputStream()` becomes unavailable before we are able to send data to it. To address this the data is first read into a file, which is then redirected as input into the "sign" process.