### PR TITLE
S3 upload fix

### DIFF
--- a/src/main/java/com/zerocracy/farm/S3Item.java
+++ b/src/main/java/com/zerocracy/farm/S3Item.java
@@ -21,7 +21,6 @@ import com.jcabi.log.Logger;
 import com.jcabi.s3.Ocket;
 import com.zerocracy.Item;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,11 +29,8 @@ import java.nio.file.attribute.FileTime;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.EqualsAndHashCode;
+import org.cactoos.io.BytesOf;
 import org.cactoos.io.InputOf;
-import org.cactoos.io.LengthOf;
-import org.cactoos.io.OutputTo;
-import org.cactoos.io.TeeInput;
-import org.cactoos.scalar.IoCheckedScalar;
 
 /**
  * Item in S3.
@@ -133,22 +129,12 @@ final class S3Item implements Item {
             final ObjectMetadata meta = new ObjectMetadata();
             final long start = System.currentTimeMillis();
             meta.setContentLength(this.temp.toFile().length());
-            final ByteArrayOutputStream buff = new ByteArrayOutputStream();
-            Logger.debug(
-                this,
-                "buffered file %s %f bytes",
-                this.temp,
-                new IoCheckedScalar<>(
-                    new LengthOf(
-                        new TeeInput(
-                            new InputOf(this.temp),
-                            new OutputTo(buff)
-                        )
-                    )
-                ).value()
-            );
             this.ocket.write(
-                new ByteArrayInputStream(buff.toByteArray()),
+                new ByteArrayInputStream(
+                    new BytesOf(
+                        new InputOf(this.temp)
+                    ).asBytes()
+                ),
                 meta
             );
             Files.setLastModifiedTime(


### PR DESCRIPTION
#987 - read temp file to memory before uploading to S3.

`Files.newInputStream()` opens new stream in `S3Item` which was never closed,
AWS-sdk is working asynchronously, so actual stream reading operation was invoked in different thread than file stream was created, `Files.newInputStream` implemented is not very clear, but looks like it may close opened previously channel-stream.

This PR ensures that temporary file is fully read before uploading (sending data to another thread). Also now we close file stream for temporary file right after read it to memory.