### PR TITLE
#843: add an ability to set job's title for agenda.

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/package-info.java
+++ b/src/main/groovy/com/zerocracy/stk/package-info.java
@@ -21,5 +21,11 @@
  * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.22
+ * @todo #843:30min Title element, of an order in agenda, has been declared in
+ *  agenda.xsd. Let's add a new stakeholder,
+ *  set_agenda_title_from_github.groovy, which will get title of a job
+ *  from GitHub and set it to Agenda. THe reason for the new stakeholder
+ *  is that not all orders will come from Github, some may also come
+ *  from Jira, Trello etc, in the future.
  */
 package com.zerocracy.stk;

--- a/src/main/java/com/zerocracy/pmo/Agenda.java
+++ b/src/main/java/com/zerocracy/pmo/Agenda.java
@@ -261,7 +261,7 @@ public final class Agenda {
         try (final Item item = this.item()) {
             new Xocument(item.path()).modify(
                 new Directives()
-                    .xpath(path(job))
+                    .xpath(Agenda.path(job))
                     .strict(1)
                     .addIf("title")
                     .set(title)

--- a/src/main/java/com/zerocracy/pmo/Agenda.java
+++ b/src/main/java/com/zerocracy/pmo/Agenda.java
@@ -35,13 +35,8 @@ import org.xembly.Directives;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.12
- * @todo #422:30min Title element, of an order in agenda, has been declared in
- *  agenda.xsd. Let's add method title(...), which will set the title of
- *  on order and add a new stakeholder, set_agenda_title_from_github.groovy,
- *  which will get title of a job from GitHub and set it to Agenda. THe reason
- *  for the new stakeholder is that not all orders will come from Github, some
- *  may also come from Jira, Trello etc, in the future.
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class Agenda {
 
     /**
@@ -124,9 +119,7 @@ public final class Agenda {
      */
     public boolean exists(final String job) throws IOException {
         try (final Item item = this.item()) {
-            return !new Xocument(item.path()).nodes(
-                String.format("/agenda/order[@job= '%s']", job)
-            ).isEmpty();
+            return !new Xocument(item.path()).nodes(Agenda.path(job)).isEmpty();
         }
     }
 
@@ -137,6 +130,7 @@ public final class Agenda {
      * @param role The role
      * @throws IOException If fails
      */
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     public void add(final Project project, final String job,
         final String role) throws IOException {
         if (this.exists(job)) {
@@ -177,7 +171,7 @@ public final class Agenda {
         try (final Item item = this.item()) {
             new Xocument(item.path()).modify(
                 new Directives()
-                    .xpath(String.format("/agenda/order[@job='%s']", job))
+                    .xpath(Agenda.path(job))
                     .strict(1)
                     .remove()
             );
@@ -215,7 +209,7 @@ public final class Agenda {
         try (final Item item = this.item()) {
             new Xocument(item.path()).modify(
                 new Directives()
-                    .xpath(String.format("/agenda/order[@job='%s' ]", job))
+                    .xpath(Agenda.path(job))
                     .strict(1)
                     .addIf("estimate")
                     .set(cash)
@@ -224,7 +218,7 @@ public final class Agenda {
     }
 
     /**
-     * Add estimate.
+     * Add impediment.
      * @param job The job to mark
      * @param reason The reason
      * @throws IOException If fails
@@ -241,10 +235,36 @@ public final class Agenda {
         try (final Item item = this.item()) {
             new Xocument(item.path()).modify(
                 new Directives()
-                    .xpath(String.format("/agenda/order[@job= '%s' ]", job))
+                    .xpath(Agenda.path(job))
                     .strict(1)
                     .addIf("impediment")
                     .set(reason)
+            );
+        }
+    }
+
+    /**
+     * Add title of the specified job.
+     * @param job The job to modify
+     * @param title The title to add
+     * @throws IOException If fails
+     */
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
+    public void title(final String job, final String title) throws IOException {
+        if (!this.exists(job)) {
+            throw new SoftException(
+                new Par(
+                    "Job %s is not in the agenda of @%s, can't set title"
+                ).say(job, this.login)
+            );
+        }
+        try (final Item item = this.item()) {
+            new Xocument(item.path()).modify(
+                new Directives()
+                    .xpath(path(job))
+                    .strict(1)
+                    .addIf("title")
+                    .set(title)
             );
         }
     }
@@ -257,6 +277,18 @@ public final class Agenda {
     private Item item() throws IOException {
         return this.pmo.acq(
             String.format("agenda/%s.xml", this.login)
+        );
+    }
+
+    /**
+     * Construct the pull path to the given job.
+     * @param job The job
+     * @return The full path to the given job
+     */
+    private static String path(final String job) {
+        return String.format(
+            "/agenda/order[@job='%s']",
+            job
         );
     }
 }

--- a/src/test/java/com/zerocracy/pmo/AgendaTest.java
+++ b/src/test/java/com/zerocracy/pmo/AgendaTest.java
@@ -18,22 +18,35 @@ package com.zerocracy.pmo;
 
 import com.jcabi.aspects.Tv;
 import com.zerocracy.Project;
+import com.zerocracy.SoftException;
+import com.zerocracy.Xocument;
 import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.fake.FkProject;
+import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * Test case for {@link Agenda}.
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.12
+ * @checkstyle AvoidDuplicateLiterals (500 lines)
  * @checkstyle JavadocMethodCheck (500 lines)
- * @checkstyle AvoidDuplicateLiterals (600 lines)
+ * @checkstyle JavadocVariableCheck (500 lines)
+ * @checkstyle StringLiteralsConcatenationCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class AgendaTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     @Test
     public void addsAndRemovesAgenda() throws Exception {
@@ -107,6 +120,40 @@ public final class AgendaTest {
         MatcherAssert.assertThat(
             agenda.jobs(first),
             Matchers.hasSize(Tv.THREE)
+        );
+    }
+
+    @Test
+    public void addTitleFailsIfNoJob() throws Exception {
+        this.exception.expect(SoftException.class);
+        this.exception.expectMessage(
+            "Job [#5](https://github.com/test5/test/issues/5) "
+                + "is not in the agenda of @user[/z]"
+                + "(https://www.0crat.com/u/user), can't set title"
+        );
+        final Path tmp = this.folder.newFolder().toPath();
+        final FkProject project = new FkProject(tmp, "AGENDPRJ1");
+        final FkFarm farm = new FkFarm(project);
+        final Agenda agenda = new Agenda(farm, "user").bootstrap();
+        agenda.title("gh:test5/test#5", "Test issue");
+    }
+
+    @Test
+    public void addTitleChangesXml() throws Exception {
+        final Path tmp = this.folder.newFolder().toPath();
+        final FkProject project = new FkProject(tmp, "AGENDPRJ2");
+        final Agenda agenda = new Agenda(
+            new FkFarm(project),
+            "user"
+        ).bootstrap();
+        final String job = "gh:test6/test#6";
+        agenda.add(project, job, "DEV");
+        final String title = "Title of the GitHub issue";
+        agenda.title(job, title);
+        MatcherAssert.assertThat(
+            new Xocument(tmp.resolve("agenda/user.xml"))
+                .xpath("agenda/order/title/text()"),
+            Matchers.contains(title)
         );
     }
 }

--- a/src/test/java/com/zerocracy/pmo/AgendaTest.java
+++ b/src/test/java/com/zerocracy/pmo/AgendaTest.java
@@ -38,7 +38,6 @@ import org.junit.rules.TemporaryFolder;
  * @checkstyle AvoidDuplicateLiterals (500 lines)
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle JavadocVariableCheck (500 lines)
- * @checkstyle StringLiteralsConcatenationCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class AgendaTest {
@@ -127,9 +126,10 @@ public final class AgendaTest {
     public void addTitleFailsIfNoJob() throws Exception {
         this.exception.expect(SoftException.class);
         this.exception.expectMessage(
-            "Job [#5](https://github.com/test5/test/issues/5) "
-                + "is not in the agenda of @user[/z]"
-                + "(https://www.0crat.com/u/user), can't set title"
+            Matchers.containsString("is not in the agenda of @user[/z]")
+        );
+        this.exception.expectMessage(
+            Matchers.containsString("can't set title")
         );
         final Path tmp = this.folder.newFolder().toPath();
         final FkProject project = new FkProject(tmp, "AGENDPRJ1");

--- a/src/test/java/com/zerocracy/pmo/AgendaTest.java
+++ b/src/test/java/com/zerocracy/pmo/AgendaTest.java
@@ -126,10 +126,10 @@ public final class AgendaTest {
     public void addTitleFailsIfNoJob() throws Exception {
         this.exception.expect(SoftException.class);
         this.exception.expectMessage(
-            Matchers.containsString("is not in the agenda of @user[/z]")
-        );
-        this.exception.expectMessage(
-            Matchers.containsString("can't set title")
+            Matchers.allOf(
+                Matchers.containsString("is not in the agenda of @user[/z]"),
+                Matchers.containsString("can't set title")
+            )
         );
         final Path tmp = this.folder.newFolder().toPath();
         final FkProject project = new FkProject(tmp, "AGENDPRJ1");


### PR DESCRIPTION
PR for #843.

I've added an ability to set job's title for agenda. As well I've added tests for this new method.

Finally, I've added a new puzzle about creating a new stakeholder `set_agenda_title_from_github.groovy` as I wasn't able to do that in 30 minutes (was fighting with code style for changed classes).