### PR TITLE
Handling not urlencoded payload

### DIFF
--- a/src/main/java/com/zerocracy/radars/github/Rebound.java
+++ b/src/main/java/com/zerocracy/radars/github/Rebound.java
@@ -77,4 +77,31 @@ public interface Rebound {
         }
     }
 
+    /**
+     * Fake rebound.
+     */
+    final class Fake implements Rebound {
+        /**
+         * Text to return.
+         */
+        private final String txt;
+        /**
+         * Ctor.
+         */
+        public Fake() {
+            this("");
+        }
+        /**
+         * Ctor.
+         * @param text Text
+         */
+        public Fake(final String text) {
+            this.txt = text;
+        }
+        @Override
+        public String react(final Farm farm, final Github github,
+            final JsonObject event) {
+            return this.txt;
+        }
+    }
 }

--- a/src/main/java/com/zerocracy/radars/github/Rebound.java
+++ b/src/main/java/com/zerocracy/radars/github/Rebound.java
@@ -76,32 +76,4 @@ public interface Rebound {
             return String.join("; ", answers);
         }
     }
-
-    /**
-     * Fake rebound.
-     */
-    final class Fake implements Rebound {
-        /**
-         * Text to return.
-         */
-        private final String txt;
-        /**
-         * Ctor.
-         */
-        public Fake() {
-            this("");
-        }
-        /**
-         * Ctor.
-         * @param text Text
-         */
-        public Fake(final String text) {
-            this.txt = text;
-        }
-        @Override
-        public String react(final Farm farm, final Github github,
-            final JsonObject event) {
-            return this.txt;
-        }
-    }
 }

--- a/src/main/java/com/zerocracy/radars/github/TkGithub.java
+++ b/src/main/java/com/zerocracy/radars/github/TkGithub.java
@@ -32,6 +32,7 @@ import javax.json.JsonObject;
 import javax.json.JsonReader;
 import javax.json.stream.JsonParsingException;
 import org.cactoos.func.UncheckedProc;
+import org.takes.HttpException;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
@@ -146,7 +147,12 @@ public final class TkGithub implements Take, Runnable {
     @Override
     public Response act(final Request req) throws IOException {
         final RqForm form = new RqFormBase(req);
-        final Iterable<String> body = form.param("payload");
+        final Iterable<String> body;
+        try {
+            body = form.param("payload");
+        } catch (final IllegalArgumentException err) {
+            throw new HttpException(HttpURLConnection.HTTP_BAD_REQUEST, err);
+        }
         if (!body.iterator().hasNext()) {
             throw new RsForward(
                 new RsParFlash(
@@ -194,12 +200,14 @@ public final class TkGithub implements Take, Runnable {
      * @return The JSON object
      */
     private static JsonObject json(final String body) {
-        try (final JsonReader reader =
-            Json.createReader(
-                new ByteArrayInputStream(
-                    body.getBytes(StandardCharsets.UTF_8)
+        try (
+            final JsonReader reader =
+                Json.createReader(
+                    new ByteArrayInputStream(
+                        body.getBytes(StandardCharsets.UTF_8)
+                    )
                 )
-            )) {
+        ) {
             return reader.readObject();
         } catch (final JsonParsingException ex) {
             throw new IllegalArgumentException(

--- a/src/test/java/com/zerocracy/radars/github/TkGithubTest.java
+++ b/src/test/java/com/zerocracy/radars/github/TkGithubTest.java
@@ -16,15 +16,13 @@
  */
 package com.zerocracy.radars.github;
 
-import com.zerocracy.Farm;
-import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.props.PropsFarm;
 import java.net.HttpURLConnection;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
-import org.takes.Take;
+import org.takes.HttpException;
 import org.takes.facets.hamcrest.HmRsStatus;
 import org.takes.rq.RqFake;
 import org.takes.rq.RqWithBody;
@@ -37,15 +35,13 @@ import org.takes.rq.RqWithBody;
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class TkGithubTest {
-
     @Test
     public void parsesJson() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
-        final Take take = new TkGithub(
-            farm, (frm, github, event) -> "nothing"
-        );
         MatcherAssert.assertThat(
-            take.act(
+            new TkGithub(
+                new PropsFarm(),
+                new Rebound.Fake("nothing")
+            ).act(
                 new RqWithBody(
                     new RqFake("POST", "/"),
                     String.format(
@@ -58,6 +54,19 @@ public final class TkGithubTest {
                 )
             ),
             new HmRsStatus(HttpURLConnection.HTTP_OK)
+        );
+    }
+
+    @Test(expected = HttpException.class)
+    public void handleNonEncodedPayload() throws Exception {
+        new TkGithub(
+            new PropsFarm(),
+            new Rebound.Fake()
+        ).act(
+            new RqWithBody(
+                new RqFake(),
+                "payload={\"x\":\"% r\"}"
+            )
         );
     }
 }

--- a/src/test/java/com/zerocracy/radars/github/TkGithubTest.java
+++ b/src/test/java/com/zerocracy/radars/github/TkGithubTest.java
@@ -40,7 +40,7 @@ public final class TkGithubTest {
         MatcherAssert.assertThat(
             new TkGithub(
                 new PropsFarm(),
-                new Rebound.Fake("nothing")
+                (farm, github, event) -> "nothing"
             ).act(
                 new RqWithBody(
                     new RqFake("POST", "/"),
@@ -61,7 +61,7 @@ public final class TkGithubTest {
     public void handleNonEncodedPayload() throws Exception {
         new TkGithub(
             new PropsFarm(),
-            new Rebound.Fake()
+            (farm, github, event) -> "none"
         ).act(
             new RqWithBody(
                 new RqFake(),


### PR DESCRIPTION
#831 - reproduced and fixed exception: it happens when form body is not urlencoded and contains `%` characters.