### PR TITLE
#601 Fix "Address already in use" issue with DynamoDB in Maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -864,10 +864,14 @@ SOFTWARE.
                 <goals>
                   <goal>reserve-network-port</goal>
                 </goals>
+                <phase>pre-integration-test</phase>
                 <configuration>
                   <portNames>
                     <portName>dynamo.port</portName>
                   </portNames>
+                  <minPortNumber>49152</minPortNumber>
+                  <maxPortNumber>65535</maxPortNumber>
+                  <randomPort>true</randomPort>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
#601: The problem is that reserving the ports is subject to a race condition; any process might be able to grab the port between execution of `reserve-network-port` and starting of Dynamo DB test.

This isn't so much a fix as it is a mitigation:
* Moved `reserve-network-port` goal to `pre-integration-test` phase. [By default](https://www.mojohaus.org/build-helper-maven-plugin/reserve-network-port-mojo.html) it runs under `process-test-classes` phase, which means it runs before we even execute unit tests. This is a hazard because the unit tests themselves allocate some network connections. Now the port reservation is done right before the Dynamo DB test itself to narrow down the time window between reservation and execution.
* Use the recommended [dynamic ports range](https://tools.ietf.org/html/rfc6335#section-6) of `49152-65535`.
* Allocate ports at random.