### PR TITLE
VsNegligence, Negligence + puzzles

### DIFF
--- a/src/main/java/com/zerocracy/pm/staff/votes/VsNegligence.java
+++ b/src/main/java/com/zerocracy/pm/staff/votes/VsNegligence.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.pm.staff.votes;
+
+import com.zerocracy.pm.staff.Votes;
+import com.zerocracy.pmo.Negligence;
+import com.zerocracy.pmo.Pmo;
+import java.io.IOException;
+
+/**
+ * Downvote user if they've been resigned from a lot of jobs because
+ * of being late (spent more than the allowed number of days on it).
+ *
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.23
+ * @todo #540:30min Test cases are missing for this class. Add some
+ *  unit tests and, when Negligence is finished (it is currently in
+ *  development), use this voter inside elect_performer.groovy -- make
+ *  sure to give it a big weight.
+ */
+public final class VsNegligence implements Votes {
+
+    /**
+     * PMO project.
+     */
+    private final Pmo pmo;
+
+    /**
+     * Ctor.
+     * @param pmo PMO project.
+     */
+    public VsNegligence(final Pmo pmo) {
+        this.pmo = pmo;
+    }
+
+    @Override
+    public double take(
+        final String login, final StringBuilder log
+    ) throws IOException {
+        final double rate;
+        if (new Negligence(this.pmo, login).bootstrap().high()) {
+            rate = 0.0d;
+        } else {
+            rate = 1.0d;
+        }
+        return rate;
+    }
+
+}

--- a/src/main/java/com/zerocracy/pmo/Negligence.java
+++ b/src/main/java/com/zerocracy/pmo/Negligence.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.pmo;
+
+import com.zerocracy.Farm;
+import com.zerocracy.Item;
+import com.zerocracy.Xocument;
+import java.io.IOException;
+
+/**
+ * Negligence. This metric calculates how many times a user has lost
+ * a job due to missing the deadline (too many days passed without a reason for
+ * waiting).
+ *
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id $
+ * @since 0.23
+ * @todo #540:30min Finish implementing and testing this class,
+ *  decide on the XML format and declare it in /datum repository.
+ *  When done, use this metric inside resin_on_delay.groovy.
+ */
+public final class Negligence {
+
+    /**
+     * Project.
+     */
+    private final Pmo pmo;
+
+    /**
+     * Login of the person.
+     */
+    private final String login;
+
+    /**
+     * Ctor.
+     * @param farm The farm
+     * @param user The user
+     */
+    public Negligence(final Farm farm, final String user) {
+        this(new Pmo(farm), user);
+    }
+
+    /**
+     * Ctor.
+     * @param pkt Pmo project
+     * @param user The user
+     */
+    public Negligence(final Pmo pkt, final String user) {
+        this.pmo = pkt;
+        this.login = user;
+    }
+
+    /**
+     * Is the user's negligence high or not?
+     * @return True if high, false otherwise.
+     */
+    public boolean high() {
+        throw new UnsupportedOperationException("Not yet implemented!");
+    }
+
+    /**
+     * Bootstrap it.
+     * @return This
+     * @throws IOException If fails
+     */
+    public Negligence bootstrap() throws IOException {
+        try (final Item item = this.item()) {
+            new Xocument(item.path()).bootstrap("pmo/negligence");
+        }
+        return this;
+    }
+
+    /**
+     * The item.
+     * @return Item
+     * @throws IOException If fails
+     */
+    private Item item() throws IOException {
+        return this.pmo.acq(
+            String.format("negligence/%s.xml", this.login)
+        );
+    }
+}


### PR DESCRIPTION
PR for #540 

Started the scaffolding of a new metric (Negligence), which should show how many times a user was resigned on delay. Also started VsNegligence voter, which should be used in the election process once ``Negligence`` is finished and they are both tested.

Left puzzles for continuing work.