### PR TITLE
#89: Implement SkSession class to wrap a real Slack session 

### DIFF
--- a/src/main/java/com/zerocracy/radars/slack/RealSkSession.java
+++ b/src/main/java/com/zerocracy/radars/slack/RealSkSession.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.radars.slack;
+
+import com.ullink.slack.simpleslackapi.SlackChannel;
+import com.ullink.slack.simpleslackapi.SlackSession;
+import com.ullink.slack.simpleslackapi.SlackUser;
+import java.io.IOException;
+
+/**
+ * Real session in Slack.
+ *
+ * @author Roman Proshin (roman@proshin.org)
+ * @version $Id$
+ * @since 0.23
+ */
+public final class RealSkSession implements SkSession {
+
+    /**
+     * Original slack session.
+     */
+    private final SlackSession origin;
+
+    /**
+     * Ctor.
+     * @param origin Original slack session
+     */
+    public RealSkSession(final SlackSession origin) {
+        this.origin = origin;
+    }
+
+    @Override
+    public SlackChannel channel(final String id) {
+        return this.origin.findChannelById(id);
+    }
+
+    @Override
+    public SlackUser user(final String id) {
+        return this.origin.findUserById(id);
+    }
+
+    @Override
+    public void send(final SlackChannel channel, final String message) {
+        this.origin.sendMessage(channel, message);
+    }
+
+    @Override
+    public void send(final SlackUser user, final String message) {
+        this.origin.sendMessage(
+            this.origin.openDirectMessageChannel(user)
+                .getReply()
+                .getSlackChannel(),
+            message
+        );
+    }
+
+    @Override
+    public boolean hasChannel(final String id) {
+        boolean has = false;
+        for (final SlackChannel channel : this.origin.getChannels()) {
+            if (channel.getId().equals(id)) {
+                has = true;
+            }
+        }
+        return has;
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.origin.disconnect();
+    }
+}

--- a/src/main/java/com/zerocracy/radars/slack/SkSession.java
+++ b/src/main/java/com/zerocracy/radars/slack/SkSession.java
@@ -18,7 +18,7 @@ package com.zerocracy.radars.slack;
 
 import com.ullink.slack.simpleslackapi.SlackChannel;
 import com.ullink.slack.simpleslackapi.SlackUser;
-import java.io.IOException;
+import java.io.Closeable;
 
 /**
  * Session in Slack.
@@ -27,9 +27,10 @@ import java.io.IOException;
  * @version $Id$
  * @since 0.23
  * @todo #89:30min Use this interface and its implementation RealSkSession
- *  everywhere instead of SlackSession.
+ *  everywhere instead of SlackSession that is used currently. When it's done
+ *  some tests can be refactored to get rid of Mockito library.
  */
-public interface SkSession extends AutoCloseable {
+public interface SkSession extends Closeable {
     /**
      * Find channel by its identifier.
      * @param id Channel identifier
@@ -65,10 +66,4 @@ public interface SkSession extends AutoCloseable {
      * @return Where this session belongs to the given channel
      */
     boolean hasChannel(String id);
-
-    /**
-     * Close the session.
-     * @throws IOException If fails
-     */
-    void close() throws IOException;
 }

--- a/src/main/java/com/zerocracy/radars/slack/SkSession.java
+++ b/src/main/java/com/zerocracy/radars/slack/SkSession.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.radars.slack;
+
+import com.ullink.slack.simpleslackapi.SlackChannel;
+import com.ullink.slack.simpleslackapi.SlackUser;
+import java.io.IOException;
+
+/**
+ * Session in Slack.
+ *
+ * @author Roman Proshin (roman@proshin.org)
+ * @version $Id$
+ * @since 0.23
+ * @todo #89:30min Use this interface and its implementation RealSkSession
+ *  everywhere instead of SlackSession.
+ */
+public interface SkSession extends AutoCloseable {
+    /**
+     * Find channel by its identifier.
+     * @param id Channel identifier
+     * @return Slack channel
+     */
+    SlackChannel channel(String id);
+
+    /**
+     * Find user by its identifier.
+     * @param id Channel identifier
+     * @return Slack user
+     */
+    SlackUser user(String id);
+
+    /**
+     * Send a message to specific channel.
+     * @param channel Slack channel
+     * @param message Message
+     */
+    void send(SlackChannel channel, String message);
+
+    /**
+     * Send a message to specific user.
+     * @param user Slack user
+     * @param message Message
+     */
+    void send(SlackUser user, String message);
+
+    /**
+     * Check whether the current session belongs to a channel with specific
+     * identifier.
+     * @param id Channel identifier
+     * @return Where this session belongs to the given channel
+     */
+    boolean hasChannel(String id);
+
+    /**
+     * Close the session.
+     * @throws IOException If fails
+     */
+    void close() throws IOException;
+}

--- a/src/test/java/com/zerocracy/radars/slack/RealSkSessionTest.java
+++ b/src/test/java/com/zerocracy/radars/slack/RealSkSessionTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.radars.slack;
+
+import com.ullink.slack.simpleslackapi.SlackChannel;
+import com.ullink.slack.simpleslackapi.SlackSession;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Test cases for {@link RealSkSession}.
+ *
+ * @author Roman Proshin (roman@proshin.org)
+ * @version $Id$
+ * @since 0.23
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class RealSkSessionTest {
+
+    @Test
+    public void channelUsesOrigin() {
+        final String id = "CHNNL";
+        final SlackSession session = Mockito.mock(SlackSession.class);
+        final SlackChannel channel = Mockito.mock(SlackChannel.class);
+        Mockito.when(session.findChannelById(id))
+            .thenReturn(channel);
+        MatcherAssert.assertThat(
+            "Session returns incorrect channel by its ID",
+            new RealSkSession(session).channel(id),
+            new IsEqual<>(channel)
+        );
+    }
+}

--- a/src/test/resources/com/zerocracy/bundles/notify_in_slack_without_user/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/notify_in_slack_without_user/_before.groovy
@@ -20,20 +20,17 @@ import com.jcabi.xml.XML
 import com.ullink.slack.simpleslackapi.SlackChannel
 import com.ullink.slack.simpleslackapi.SlackSession
 import com.ullink.slack.simpleslackapi.SlackUser
-import com.zerocracy.entry.ExtSlack
 import com.zerocracy.Farm
 import com.zerocracy.Project
+import com.zerocracy.entry.ExtSlack
 import com.zerocracy.pm.ClaimOut
 import org.cactoos.list.SolidList
 import org.mockito.Mockito
 
 /**
- * @todo #62:30min We have to implement simple
- *  slack session object to use inside 'notify_in_slack'
- *  stakeholder-script and fake object for tests.
- *  This session object may wrap `SlackSession` from
- *  `com.ullink.slack.simpleslackapi`.
- *  After that we should get rid of `Mockito` in this test.
+ * @todo # 89:30min Add a new class FakeSkSession that implements interface
+ *  SkSession, and then use this new class in tests instead of using Mockito.
+ *  This task can be implemented only when SkSession replaces SlackSession.
  */
 def exec(Project project, XML xml) {
   String channelId = 'C123'

--- a/src/test/resources/com/zerocracy/bundles/notify_in_slack_without_user/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/notify_in_slack_without_user/_before.groovy
@@ -28,7 +28,7 @@ import org.cactoos.list.SolidList
 import org.mockito.Mockito
 
 /**
- * @todo # 89:30min Add a new class FakeSkSession that implements interface
+ * @todo #89:30min Add a new class FkSkSession that implements interface
  *  SkSession, and then use this new class in tests instead of using Mockito.
  *  This task can be implemented only when SkSession replaces SlackSession.
  */


### PR DESCRIPTION
PR for #89. 

I've added a new interface SkSession that should be used instead of SlackSession which is closed for decorating. As well I've added an implementation of this interface - RealSkSession that wraps an instance of SlackSession.

I've added two new puzzles:
- integrate SkSession so that it replaces SlackSession in the code, 
- create fake SkSession class that can be used in tests.