### PR TITLE
Check repo access on assign role

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pm/staff/roles/assign_role.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/staff/roles/assign_role.groovy
@@ -57,21 +57,16 @@ def exec(Project project, XML xml) {
     )
   }
   Github github = new ExtGithub(farm).value()
-  boolean hasAccess = true
   for (String link: new Catalog(farm).links(project.pid(), 'github')) {
     Repo.Smart repo = new Repo.Smart(github.repos().get(new Coordinates.Simple(link)))
     if (repo.private && !repo.collaborators().isCollaborator(login)) {
-      hasAccess = false
-      break
+      throw new SoftException(
+        new Par(
+          '@%s doesn\'t have an access in your repositories,',
+          'we won\'t be able to assign tasks'
+        ).say(login)
+      )
     }
-  }
-  if (!hasAccess) {
-    throw new SoftException(
-      new Par(
-        '@%s doesn\'t have an access in your repositories,',
-        'we won\'t be able to assign tasks'
-      ).say(login)
-    )
   }
   Roles roles = new Roles(project).bootstrap()
   Rates rates = new Rates(project).bootstrap()

--- a/src/main/groovy/com/zerocracy/stk/pm/staff/roles/assign_role.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/staff/roles/assign_role.groovy
@@ -16,16 +16,21 @@
  */
 package com.zerocracy.stk.pm.staff.roles
 
+import com.jcabi.github.Coordinates
+import com.jcabi.github.Github
+import com.jcabi.github.Repo
 import com.jcabi.xml.XML
 import com.zerocracy.Farm
 import com.zerocracy.Par
 import com.zerocracy.Project
 import com.zerocracy.SoftException
 import com.zerocracy.cash.Cash
+import com.zerocracy.entry.ExtGithub
 import com.zerocracy.farm.Assume
 import com.zerocracy.pm.ClaimIn
 import com.zerocracy.pm.cost.Rates
 import com.zerocracy.pm.staff.Roles
+import com.zerocracy.pmo.Catalog
 import com.zerocracy.pmo.People
 
 def exec(Project project, XML xml) {
@@ -48,6 +53,23 @@ def exec(Project project, XML xml) {
         '@%s doesn\'t have a payment method configured yet,',
         'we won\'t be able to pay them;',
         'the rate can\'t be set.'
+      ).say(login)
+    )
+  }
+  Github github = new ExtGithub(farm).value()
+  boolean hasAccess = true
+  for (String link: new Catalog(farm).links(project.pid(), 'github')) {
+    Repo.Smart repo = new Repo.Smart(github.repos().get(new Coordinates.Simple(link)))
+    if (repo.private && !repo.collaborators().isCollaborator(login)) {
+      hasAccess = false
+      break
+    }
+  }
+  if (!hasAccess) {
+    throw new SoftException(
+      new Par(
+        '@%s doesn\'t have an access in your repositories,',
+        'we won\'t be able to assign tasks'
       ).say(login)
     )
   }

--- a/src/test/resources/com/zerocracy/bundles/assign_role/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/assign_role/_after.groovy
@@ -31,8 +31,8 @@ def exec(Project project, XML xml) {
   )
   // @todo #989:30min MkGithub can't create private repository,
   //  any repository from MkGithub is public, see _before in this test.
-  //  I suppose it's bug in jcabi-github so we need to submit it there
-  //  and uncomment this assertion then.
+  //  I suppose it's bug in jcabi-github, see
+  //  https://github.com/jcabi/jcabi-github/issues/1421
 //  MatcherAssert.assertThat(
 //    'DEV role was assigned to anonymous',
 //    roles.allRoles('anonymous'),

--- a/src/test/resources/com/zerocracy/bundles/assign_role/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/assign_role/_after.groovy
@@ -33,6 +33,7 @@ def exec(Project project, XML xml) {
   //  any repository from MkGithub is public, see _before in this test.
   //  I suppose it's bug in jcabi-github, see
   //  https://github.com/jcabi/jcabi-github/issues/1421
+  //  When the bug is fixed, update jcabi-github and uncomment code below.
 //  MatcherAssert.assertThat(
 //    'DEV role was assigned to anonymous',
 //    roles.allRoles('anonymous'),

--- a/src/test/resources/com/zerocracy/bundles/assign_role/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/assign_role/_after.groovy
@@ -23,8 +23,19 @@ import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 
 def exec(Project project, XML xml) {
+  Roles roles = new Roles(project).bootstrap()
   MatcherAssert.assertThat(
-    new Roles(project).bootstrap().allRoles('g4s8'),
+    'DEV roles was not assigned to g4s8',
+    roles.allRoles('g4s8'),
     Matchers.contains(Matchers.equalTo('DEV'))
   )
+  // @todo #989:30min MkGithub can't create private repository,
+  //  any repository from MkGithub is public, see _before in this test.
+  //  I suppose it's bug in jcabi-github so we need to submit it there
+  //  and uncomment this assertion then.
+//  MatcherAssert.assertThat(
+//    'DEV role was assigned to anonymous',
+//    roles.allRoles('anonymous'),
+//    Matchers.emptyIterable()
+//  )
 }

--- a/src/test/resources/com/zerocracy/bundles/assign_role/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/assign_role/_before.groovy
@@ -16,8 +16,19 @@
  */
 package com.zerocracy.bundles.assign_role
 
+import com.jcabi.github.Repo
+import com.jcabi.github.Repos
 import com.jcabi.xml.XML
+import com.zerocracy.Farm
 import com.zerocracy.Project
+import com.zerocracy.entry.ExtGithub
+import com.zerocracy.pmo.Catalog
 
 def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  Repo repo = new ExtGithub(farm).value().repos().create(
+    new Repos.RepoCreate("prvt", true)
+  )
+  repo.collaborators().add("g4s8")
+  new Catalog(farm).link(project.pid(), 'github', repo.coordinates().toString())
 }

--- a/src/test/resources/com/zerocracy/bundles/assign_role/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/assign_role/_before.groovy
@@ -27,8 +27,8 @@ import com.zerocracy.pmo.Catalog
 def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
   Repo repo = new ExtGithub(farm).value().repos().create(
-    new Repos.RepoCreate("prvt", true)
+    new Repos.RepoCreate('prvt', true)
   )
-  repo.collaborators().add("g4s8")
+  repo.collaborators().add('g4s8')
   new Catalog(farm).link(project.pid(), 'github', repo.coordinates().toString())
 }

--- a/src/test/resources/com/zerocracy/bundles/assign_role/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/assign_role/claims.xml
@@ -16,7 +16,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
 <claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.37/xsd/pm/claims.xsd" version="0.1" updated="2017-03-27T11:18:09.228Z">
-  <claim id="3">
+  <claim id="2">
     <created>2017-03-27T11:18:09.228Z</created>
     <type>Assign role</type>
     <author>yegor256</author>
@@ -24,6 +24,16 @@ SOFTWARE.
     <params>
       <param name="role">DEV</param>
       <param name="login">g4s8</param>
+    </params>
+  </claim>
+  <claim id="3">
+    <created>2017-03-27T11:18:09.228Z</created>
+    <type>Assign role</type>
+    <author>yegor256</author>
+    <token>test;C123;yegor256</token>
+    <params>
+      <param name="role">DEV</param>
+      <param name="login">anonymous</param>
     </params>
   </claim>
   <claim id="4">

--- a/src/test/resources/com/zerocracy/bundles/assign_role/people.xml
+++ b/src/test/resources/com/zerocracy/bundles/assign_role/people.xml
@@ -19,4 +19,7 @@ SOFTWARE.
   <person id="g4s8">
     <mentor>yegor256</mentor>
   </person>
+  <person id="anonymous">
+    <mentor>yegor256</mentor>
+  </person>
 </people>


### PR DESCRIPTION
#989 - check access in repo on assign role, if repository is private and user is not a collaborator `assign_role` will fail.

Test is not working because of bug: https://github.com/jcabi/jcabi-github/issues/1421 