### PR TITLE
#1050 fixed Footprint tests

### DIFF
--- a/src/main/java/com/zerocracy/entry/ExtMongo.java
+++ b/src/main/java/com/zerocracy/entry/ExtMongo.java
@@ -36,9 +36,9 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.util.concurrent.TimeUnit;
 import org.cactoos.Scalar;
+import org.cactoos.func.SolidFunc;
+import org.cactoos.func.UncheckedFunc;
 import org.cactoos.list.SolidList;
-import org.cactoos.scalar.SolidScalar;
-import org.cactoos.scalar.UncheckedScalar;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -56,9 +56,10 @@ public final class ExtMongo implements Scalar<MongoClient> {
      * Thread with Mongodb.
      * @checkstyle ConstantUsageCheck (5 lines)
      */
-    private static final UncheckedScalar<Integer> FAKE = new UncheckedScalar<>(
-        new SolidScalar<>(
-            () -> {
+    private static final UncheckedFunc<Long, Integer> FAKE =
+        new UncheckedFunc<>(
+        new SolidFunc<>(
+            (id) -> {
                 final int port;
                 try (ServerSocket socket = new ServerSocket()) {
                     socket.setReuseAddress(true);
@@ -118,7 +119,7 @@ public final class ExtMongo implements Scalar<MongoClient> {
         final MongoClient client;
         if (props.has("//testing")) {
             client = new MongoClient(
-                "localhost", ExtMongo.FAKE.value()
+                "localhost", ExtMongo.FAKE.apply(Thread.currentThread().getId())
             );
         } else {
             // @checkstyle MagicNumber (5 lines)

--- a/src/test/java/com/zerocracy/pm/FootprintTest.java
+++ b/src/test/java/com/zerocracy/pm/FootprintTest.java
@@ -18,10 +18,12 @@ package com.zerocracy.pm;
 
 import com.jcabi.aspects.Tv;
 import com.jcabi.xml.XML;
+import com.mongodb.MongoClient;
 import com.mongodb.client.model.Filters;
 import com.zerocracy.Farm;
 import com.zerocracy.Project;
 import com.zerocracy.RunsInThreads;
+import com.zerocracy.entry.ExtMongo;
 import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.farm.sync.SyncFarm;
 import java.util.Date;
@@ -73,8 +75,9 @@ public final class FootprintTest {
                     new ClaimOut().type("Version").postTo(project);
                     final XML xml = new Claims(project)
                         .iterate().iterator().next();
+                    final MongoClient mongo = new ExtMongo(farm).value();
                     try (final Footprint footprint =
-                        new Footprint(farm, project)) {
+                        new Footprint(mongo, project.pid())) {
                         footprint.open(xml);
                         footprint.close(xml);
                         return footprint.collection().find(


### PR DESCRIPTION
#1050 
The problem was that we run the tests concurrently and one footprint tests were sometimes breaking the others.
So I made mongo db start depend on thread id and this solved the problem.