### PR TITLE
For #1147: Each user should see the status of his/her resume at /join.

### DIFF
--- a/src/main/java/com/zerocracy/tk/TkJoin.java
+++ b/src/main/java/com/zerocracy/tk/TkJoin.java
@@ -42,12 +42,14 @@ import org.takes.rq.form.RqFormSmart;
  * @author Kirill (g4s8.public@gmail.com)
  * @version $Id$
  * @since 0.20
- * @todo #908:30min Each user should see the status of his/her resume at /join.
+ * @todo #1147:30min Each user should see the status of his/her resume at /join.
  *  If the resume is there, he/she should see the resume, not the form.
  *  If he/she already has a mentor, there should be a redirect,
  *  saying that "User @yegor256 is already your mentor, no need to join again".
  *  See https://github.com/zerocracy/farm/issues/800#issuecomment-375551970
- *  comment for details.
+ *  comment for details. These two conditions are already tested in
+ *  TkJoinTest, in showResumeIfAlreadyApplied and showAlreadyHasMentor, and
+ *  the ignore tag on the tests should be removed upon puzzle completion.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")

--- a/src/test/java/com/zerocracy/tk/TkJoinTest.java
+++ b/src/test/java/com/zerocracy/tk/TkJoinTest.java
@@ -21,10 +21,14 @@ import com.zerocracy.Farm;
 import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pmo.People;
+import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Date;
+import org.cactoos.iterable.IterableOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.text.StringContainsInOrder;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.takes.facets.hamcrest.HmRsHeader;
 import org.takes.facets.hamcrest.HmRsStatus;
@@ -124,6 +128,65 @@ public final class TkJoinTest {
             Matchers.allOf(
                 new HmRsStatus(HttpURLConnection.HTTP_SEE_OTHER),
                 new HmRsHeader("Location", "/")
+            )
+        );
+    }
+
+    /**
+     * {@link TkJoin} can show that user already has a mentor. TkJoin must
+     * show a message to user when he or she tries to access
+     * <code>/join</code> but already has a mentor, which means that the user
+     * has already joined or asked for menthor for joining.
+     * @throws IOException If something goes wrong accessing page.
+     */
+    @Test
+    @Ignore
+    public void showThatUserAlreadyHasMentor() throws IOException {
+        final Farm farm = new PropsFarm(new FkFarm());
+        final People people = new People(farm).bootstrap();
+        final String uid = "yegor256";
+        people.touch(uid);
+        people.apply(uid, new Date());
+        MatcherAssert.assertThat(
+            new RsPrint(
+                new TkApp(farm).act(
+                    new RqWithUser(farm, new RqFake("GET", "/join"))
+                )
+            ).printBody(),
+            new StringContainsInOrder(
+                new IterableOf<String>(
+                    "User",
+                    "is already your mentor, no need to join again"
+                )
+            )
+        );
+    }
+
+    /**
+     * {@link TkJoin} can show resume if user already applied. TkJoin must
+     * show user's resume, if there is one, when user tries to access
+     * <code>/join</code> endpoint.
+     * @throws IOException If something goes wrong accessing page.
+     */
+    @Test
+    @Ignore
+    public void showResumeIfAlreadyApplied() throws Exception {
+        final Farm farm = new PropsFarm(new FkFarm());
+        final People people = new People(farm).bootstrap();
+        final String uid = "yegor256";
+        people.touch(uid);
+        people.apply(uid, new Date());
+        MatcherAssert.assertThat(
+            new RsPrint(
+                new TkApp(farm).act(
+                    new RqWithUser(farm, new RqFake("GET", "/join"))
+                )
+            ).printBody(),
+            new StringContainsInOrder(
+                new IterableOf<String>(
+                    "User",
+                    "here is your resume."
+                )
             )
         );
     }

--- a/src/test/java/com/zerocracy/tk/TkJoinTest.java
+++ b/src/test/java/com/zerocracy/tk/TkJoinTest.java
@@ -25,6 +25,9 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Date;
 import org.cactoos.iterable.IterableOf;
+import org.cactoos.matchers.TextHasString;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.text.StringContainsInOrder;
@@ -133,44 +136,49 @@ public final class TkJoinTest {
     }
 
     /**
-     * {@link TkJoin} can show that user already has a mentor. TkJoin must
-     * show a message to user when he or she tries to access
+     * {@link TkJoin} can show that user already has a mentor.
+     * {@link TkJoin} must show a message to user when he or she tries to access
      * <code>/join</code> but already has a mentor, which means that the user
-     * has already joined or asked for menthor for joining.
-     * @throws IOException If something goes wrong accessing page.
+     * has already joined or asked for mentor for joining.
+     * @throws IOException If something goes wrong accessing page
      */
     @Test
     @Ignore
-    public void showThatUserAlreadyHasMentor() throws IOException {
+    public void showsThatUserAlreadyHasMentor() throws IOException {
         final Farm farm = new PropsFarm(new FkFarm());
         final People people = new People(farm).bootstrap();
-        final String uid = "yegor256";
-        people.touch(uid);
-        people.apply(uid, new Date());
+        final String mentorid = "yoda";
+        final String userid = "luke";
+        people.touch(mentorid);
+        people.touch(userid);
+        people.apply(userid, new Date());
+        people.invite(userid, mentorid);
         MatcherAssert.assertThat(
-            new RsPrint(
-                new TkApp(farm).act(
-                    new RqWithUser(farm, new RqFake("GET", "/join"))
-                )
-            ).printBody(),
-            new StringContainsInOrder(
-                new IterableOf<String>(
-                    "User",
-                    "is already your mentor, no need to join again"
-                )
+            new TextOf(
+                new RsPrint(
+                    new TkApp(farm).act(
+                        new RqWithUser(farm, new RqFake("GET", "/join"))
+                    )
+                ).printBody()
+            ),
+            new TextHasString(
+                new FormattedText(
+                    "User %s is already your mentor, no need to join again",
+                    mentorid
+                ).asString()
             )
         );
     }
 
     /**
-     * {@link TkJoin} can show resume if user already applied. TkJoin must
-     * show user's resume, if there is one, when user tries to access
-     * <code>/join</code> endpoint.
-     * @throws IOException If something goes wrong accessing page.
+     * {@link TkJoin} can show resume if user already applied.
+     * {@link TkJoin} must show user's resume, if there is one, when user tries
+     * to access <code>/join</code> endpoint.
+     * @throws IOException If something goes wrong accessing page
      */
     @Test
     @Ignore
-    public void showResumeIfAlreadyApplied() throws Exception {
+    public void showsResumeIfAlreadyApplied() throws Exception {
         final Farm farm = new PropsFarm(new FkFarm());
         final People people = new People(farm).bootstrap();
         final String uid = "yegor256";


### PR DESCRIPTION
For #1147:
- Created test in `TkJoinTest` which tests if user is seeing page telling that he /she already has a mentor;
- Created test in `TkJoinTest` which tests if user is seeing resume on page, it he / she already has a resume.
- Added in puzzle the info about ticket implementation.