### PR TITLE
#556 Re-enable S3ItemTest.handleThreadInterruptionCorrectly

### DIFF
--- a/src/test/java/com/zerocracy/farm/S3ItemTest.java
+++ b/src/test/java/com/zerocracy/farm/S3ItemTest.java
@@ -31,7 +31,6 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileTime;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.xembly.Directives;
 
@@ -125,15 +124,8 @@ public final class S3ItemTest {
 
     /**
      * Test with ocket which simulates async work of real S3 client.
-     * @checkstyle AnonInnerLengthCheck (500 lines)
-     * @todo #511:30min S3Item does not handle InterruptedException properly.
-     *  It should not allow reading from io.channel stream if thread was
-     *  interrupted because it automatically check thread status before
-     *  reading and can throw `ClosedChannelException`.
      */
     @Test
-    @SuppressWarnings("ResultOfMethodCallIgnored")
-    @Ignore
     public void handleThreadInterruptionCorrectly() throws Exception {
         final Path target = Files.createTempFile("", "");
         final Ocket okt = new OcktInterrupted(


### PR DESCRIPTION
#556: It appears that the original bug was fixed in PR #1065 (see issue #987). In that PR, the original `Files.newInputStream` implementation was changed into the existing one, avoiding the `ClosedChannelException` issue. I managed to reproduce the bug by reverting to the prior code.

Re-enabled test (and removed a couple of extraneous warning suppressions as well).