### PR TITLE
Fix travis build so we will see qulice errors

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,4 +1,4 @@
 set -e
 pdd --source=$(pwd) --verbose --file=/dev/null
-mvn clean install -Pqulice,codenarc --errors --batch-mode --quiet
+mvn clean install -Pqulice,codenarc --errors --batch-mode
 mvn clean --quiet


### PR DESCRIPTION
When using `--quiet` no INFO messages from qulice are shown, I removed it.