### PR TITLE
#1243 Don't penalize PMO project members for breakup

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pmo/profile/penalize_for_breakup.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pmo/profile/penalize_for_breakup.groovy
@@ -23,16 +23,16 @@ import com.zerocracy.Policy
 import com.zerocracy.Project
 import com.zerocracy.farm.Assume
 import com.zerocracy.pm.ClaimIn
+import com.zerocracy.pm.staff.Roles
 import com.zerocracy.pmo.Awards
-import com.zerocracy.pmo.Projects
-
+import com.zerocracy.pmo.Pmo
 
 def exec(Project pmo, XML xml) {
   new Assume(pmo, xml).isPmo()
   new Assume(pmo, xml).type('Breakup')
   ClaimIn claim = new ClaimIn(xml)
   String author = claim.author()
-  if (new Projects(farm, author).bootstrap().exists('PMO')) {
+  if (new Roles(new Pmo(farm)).bootstrap().hasAnyRole(author)) {
     return
   }
   String student = claim.param('login')

--- a/src/main/groovy/com/zerocracy/stk/pmo/profile/penalize_for_breakup.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pmo/profile/penalize_for_breakup.groovy
@@ -24,14 +24,18 @@ import com.zerocracy.Project
 import com.zerocracy.farm.Assume
 import com.zerocracy.pm.ClaimIn
 import com.zerocracy.pmo.Awards
+import com.zerocracy.pmo.Projects
 
 
 def exec(Project pmo, XML xml) {
   new Assume(pmo, xml).isPmo()
   new Assume(pmo, xml).type('Breakup')
   ClaimIn claim = new ClaimIn(xml)
-  String student = claim.param('login')
   String author = claim.author()
+  if (new Projects(farm, author).bootstrap().exists('PMO')) {
+    return
+  }
+  String student = claim.param('login')
   String job = 'gh:zerocracy/datum#1'
   int points = -new Policy().get('47.penalty', 256)
   String reason = new Par(

--- a/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/_after.groovy
@@ -14,7 +14,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.zerocracy.bundles.invite_a_friend
+package com.zerocracy.bundles.dont_penalize_pmo_member_for_breakup
 
 import com.jcabi.xml.XML
 import com.zerocracy.Project
@@ -24,7 +24,7 @@ import org.hamcrest.Matchers
 
 def exec(Project project, XML xml) {
   MatcherAssert.assertThat(
-    '256 points deducted from PMO member',
+    'Points should not have been deducted from PMO member!',
     new Awards(binding.variables.farm, 'carlosmiranda').total(),
     Matchers.is(256)
   )

--- a/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/_after.groovy
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.invite_a_friend
+
+import com.jcabi.xml.XML
+import com.zerocracy.Project
+import com.zerocracy.pmo.Awards
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+def exec(Project project, XML xml) {
+  MatcherAssert.assertThat(
+    '256 points deducted from PMO member',
+    new Awards(binding.variables.farm, 'carlosmiranda').total(),
+    Matchers.is(256)
+  )
+}

--- a/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/_before.groovy
@@ -21,8 +21,9 @@ import com.jcabi.xml.XML
 import com.zerocracy.Farm
 import com.zerocracy.Project
 import com.zerocracy.entry.ExtGithub
+import com.zerocracy.pm.staff.Roles
 import com.zerocracy.pmo.Awards
-import com.zerocracy.pmo.Projects
+import com.zerocracy.pmo.Pmo
 
 def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
@@ -30,5 +31,5 @@ def exec(Project project, XML xml) {
   new Awards(farm, 'carlosmiranda').bootstrap().add(
     project, 256, 'gh:test/test#1', 'test'
   )
-  new Projects(farm, 'carlosmiranda').bootstrap().add('PMO')
+  new Roles(new Pmo(farm)).bootstrap().assign('carlosmiranda', 'PO')
 }

--- a/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/_before.groovy
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.invite_a_friend
+
+import com.jcabi.github.Repos
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.entry.ExtGithub
+import com.zerocracy.pmo.Awards
+import com.zerocracy.pmo.Projects
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  new ExtGithub(farm).value().repos().create(new Repos.RepoCreate('test', false))
+  new Awards(farm, 'carlosmiranda').bootstrap().add(
+    project, 256, 'gh:test/test#1', 'test'
+  )
+  new Projects(farm, 'carlosmiranda').bootstrap().add('PMO')
+}

--- a/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/_before.groovy
@@ -14,7 +14,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.zerocracy.bundles.invite_a_friend
+package com.zerocracy.bundles.dont_penalize_pmo_member_for_breakup
 
 import com.jcabi.github.Repos
 import com.jcabi.xml.XML

--- a/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/_setup.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/_setup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<setup>
+  <pmo>true</pmo>
+</setup>

--- a/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/claims.xml
@@ -16,15 +16,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
 <claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.27/xsd/pm/claims.xsd" version="0.1" updated="2017-03-27T11:18:09.228Z">
-  <!--claim id="1">
-    <type>Invite a friend</type>
-    <token>job;gh:test/test#1</token>
-    <author>carlosmiranda</author>
-    <params>
-      <param name="login">krzyk</param>
-    </params>
-    <created>2017-01-15T01:00:00.000Z</created>
-  </claim-->
   <claim id="4">
     <type>Breakup</type>
     <token>job;gh:test/test#1</token>

--- a/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/claims.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.27/xsd/pm/claims.xsd" version="0.1" updated="2017-03-27T11:18:09.228Z">
+  <!--claim id="1">
+    <type>Invite a friend</type>
+    <token>job;gh:test/test#1</token>
+    <author>carlosmiranda</author>
+    <params>
+      <param name="login">krzyk</param>
+    </params>
+    <created>2017-01-15T01:00:00.000Z</created>
+  </claim-->
+  <claim id="4">
+    <type>Breakup</type>
+    <token>job;gh:test/test#1</token>
+    <author>carlosmiranda</author>
+    <params>
+      <param name="login">krzyk</param>
+    </params>
+    <created>2017-01-15T01:00:00.000Z</created>
+  </claim>
+</claims>

--- a/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/people.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_penalize_pmo_member_for_breakup/people.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<people xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.28/xsd/pmo/people.xsd" version="1" updated="2016-12-29T09:03:21.684Z">
+  <person id="carlosmiranda">
+    <mentor>0crat</mentor>
+  </person>
+  <person id="krzyk">
+    <mentor>carlosmiranda</mentor>
+  </person>
+</people>


### PR DESCRIPTION
#1243: Modified `penalize_for_breakup.groovy` stakeholder to avoid penalizing PMO members when breaking up with students. Added Bundles test case for this scenario.