### PR TITLE
#841 Store agenda count in people.xml

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pmo/agenda/update_person_agenda_count.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pmo/agenda/update_person_agenda_count.groovy
@@ -26,7 +26,6 @@ import com.zerocracy.pmo.People
 import org.cactoos.iterable.LengthOf
 
 def exec(Project project, XML xml) {
-  new Assume(project, xml).notPmo()
   new Assume(project, xml).type('Agenda was updated')
   Farm farm = binding.variables.farm
   String login = new ClaimIn(xml).param('login')

--- a/src/main/groovy/com/zerocracy/stk/pmo/agenda/update_person_agenda_count.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pmo/agenda/update_person_agenda_count.groovy
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.stk.pmo.agenda
+
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.farm.Assume
+import com.zerocracy.pm.ClaimIn
+import com.zerocracy.pmo.Agenda
+import com.zerocracy.pmo.People
+import org.cactoos.iterable.LengthOf
+
+def exec(Project project, XML xml) {
+  new Assume(project, xml).notPmo()
+  new Assume(project, xml).type('Agenda was updated')
+  Farm farm = binding.variables.farm
+  String login = new ClaimIn(xml).param('login')
+  new People(farm).bootstrap().jobs(
+    login,
+    new LengthOf(
+        new Agenda(farm, login).bootstrap().jobs()
+    ).intValue()
+  )
+}

--- a/src/main/groovy/com/zerocracy/stk/pmo/agenda/update_person_agenda_count.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pmo/agenda/update_person_agenda_count.groovy
@@ -30,10 +30,13 @@ def exec(Project project, XML xml) {
   new Assume(project, xml).type('Agenda was updated')
   Farm farm = binding.variables.farm
   String login = new ClaimIn(xml).param('login')
-  new People(farm).bootstrap().jobs(
-    login,
-    new LengthOf(
+  People people = new People(farm).bootstrap()
+  if (people.exists(login)) {
+    people.jobs(
+      login,
+      new LengthOf(
         new Agenda(farm, login).bootstrap().jobs()
-    ).intValue()
-  )
+      ).intValue()
+    )
+  }
 }

--- a/src/main/java/com/zerocracy/pmo/People.java
+++ b/src/main/java/com/zerocracy/pmo/People.java
@@ -43,10 +43,6 @@ import org.xembly.Directives;
  * @version $Id$
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.1
- * @todo #552:30min Let's keep agenda inside `people.xml` and update it
- *  when agenda changed as described in
- *  https://github.com/zerocracy/farm/issues/366#issuecomment-359568311
- *  Also put it as 'agenda' element in TkGang xml.
  */
 @SuppressWarnings
     (

--- a/src/test/resources/com/zerocracy/bundles/refresh_person_job_count_on_agenda_update/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/refresh_person_job_count_on_agenda_update/_after.groovy
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.refresh_person_job_count_on_agenda_update
+
+import com.jcabi.xml.XML
+import com.zerocracy.Project
+import com.zerocracy.pmo.People
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+def exec(Project project, XML xml) {
+  MatcherAssert.assertThat(
+    new People(binding.variables.farm).bootstrap().jobs('carlosmiranda'),
+    Matchers.is(3)
+  )
+}

--- a/src/test/resources/com/zerocracy/bundles/refresh_person_job_count_on_agenda_update/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/refresh_person_job_count_on_agenda_update/_before.groovy
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.refresh_person_job_count_on_agenda_update
+
+import com.jcabi.xml.XML
+import com.zerocracy.Project
+import com.zerocracy.pmo.Agenda
+
+def exec(Project project, XML xml) {
+  new Agenda(binding.variables.farm, 'carlosmiranda').bootstrap().with {
+    add project, 'gh:test/agenda#1', 'DEV'
+    add project, 'gh:test/agenda#2', 'DEV'
+    add project, 'gh:test/agenda#3', 'DEV'
+  }
+}

--- a/src/test/resources/com/zerocracy/bundles/refresh_person_job_count_on_agenda_update/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/refresh_person_job_count_on_agenda_update/_before.groovy
@@ -17,11 +17,20 @@
 package com.zerocracy.bundles.refresh_person_job_count_on_agenda_update
 
 import com.jcabi.xml.XML
+import com.zerocracy.Farm
 import com.zerocracy.Project
 import com.zerocracy.pmo.Agenda
+import com.zerocracy.pmo.People
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
 
 def exec(Project project, XML xml) {
-  new Agenda(binding.variables.farm, 'carlosmiranda').bootstrap().with {
+  Farm farm = binding.variables.farm
+  MatcherAssert.assertThat(
+    new People(farm).bootstrap().jobs('carlosmiranda'),
+    Matchers.is(0)
+  )
+  new Agenda(farm, 'carlosmiranda').bootstrap().with {
     add project, 'gh:test/agenda#1', 'DEV'
     add project, 'gh:test/agenda#2', 'DEV'
     add project, 'gh:test/agenda#3', 'DEV'

--- a/src/test/resources/com/zerocracy/bundles/refresh_person_job_count_on_agenda_update/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/refresh_person_job_count_on_agenda_update/claims.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.2/xsd/pm/claims.xsd" version="0.1" updated="2017-03-27T11:18:09.228Z">
+  <claim id="3">
+    <created>2018-06-28T18:00:00.000Z</created>
+    <type>Agenda was updated</type>
+    <params>
+      <param name="login">carlosmiranda</param>
+    </params>
+  </claim>
+</claims>

--- a/src/test/resources/com/zerocracy/bundles/refresh_person_job_count_on_agenda_update/people.xml
+++ b/src/test/resources/com/zerocracy/bundles/refresh_person_job_count_on_agenda_update/people.xml
@@ -21,7 +21,7 @@ SOFTWARE.
     <rate>$39</rate>
     <reputation>1000</reputation>
     <details>Some details</details>
-    <jobs>1</jobs>
+    <jobs>0</jobs>
     <speed>2.0</speed>
     <projects>1</projects>
     <wallet bank="paypal">test@paypal.com</wallet>

--- a/src/test/resources/com/zerocracy/bundles/refresh_person_job_count_on_agenda_update/people.xml
+++ b/src/test/resources/com/zerocracy/bundles/refresh_person_job_count_on_agenda_update/people.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<people xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.2/xsd/pmo/people.xsd" version="1" updated="2016-12-29T09:03:21.684Z">
+  <person id="carlosmiranda">
+    <mentor>0crat</mentor>
+    <rate>$39</rate>
+    <reputation>1000</reputation>
+    <details>Some details</details>
+    <jobs>1</jobs>
+    <speed>2.0</speed>
+    <projects>1</projects>
+    <wallet bank="paypal">test@paypal.com</wallet>
+    <links/>
+    <vacation>false</vacation>
+    <skills updated="2018-01-01T00:00:00.000Z"/>
+  </person>
+</people>


### PR DESCRIPTION
#841: Agenda count is now stored in `people.xml` and refreshed for each `Agenda was updated` claim. Added corresponding `BundlesTest` case to suit.