### PR TITLE
#1245 Fix handling of errors during adding of claims

### DIFF
--- a/src/main/java/com/zerocracy/farm/StkSafe.java
+++ b/src/main/java/com/zerocracy/farm/StkSafe.java
@@ -27,8 +27,6 @@ import com.zerocracy.pm.Claims;
 import com.zerocracy.tools.TxtUnrecoverableError;
 import io.sentry.Sentry;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Objects;
 import lombok.EqualsAndHashCode;
 import org.cactoos.text.TextOf;
 
@@ -144,7 +142,7 @@ public final class StkSafe implements Stakeholder {
         if (new Props(this.farm).has("//testing")) {
             throw new IllegalStateException(exception);
         }
-        if (!StkSafe.fromClaimsAdd(exception)) {
+        if (!(Claims.AddException.class.isInstance(exception))) {
             claim.copy()
                 .type("Error")
                 .param("origin_id", claim.cid())
@@ -153,20 +151,5 @@ public final class StkSafe implements Stakeholder {
                 .param("stacktrace", new TextOf(exception).asString())
                 .postTo(project);
         }
-    }
-
-    /**
-     * Is this exception from a Claims.add method?
-     * @param throwable Throwable to check
-     * @return True if from Claims.add
-     */
-    private static boolean fromClaimsAdd(final Throwable throwable) {
-        return throwable.getStackTrace() != null
-            && Arrays.stream(throwable.getStackTrace())
-            .anyMatch(
-                trace -> Objects.equals(
-                    trace.getClassName(), Claims.class.getCanonicalName()
-                ) && Objects.equals(trace.getMethodName(), "add")
-            );
     }
 }

--- a/src/main/java/com/zerocracy/pm/Claims.java
+++ b/src/main/java/com/zerocracy/pm/Claims.java
@@ -90,9 +90,9 @@ public final class Claims {
     /**
      * Add new directives.
      * @param claim The claim to add
-     * @throws IOException If fails
      */
-    public void add(final Iterable<Directive> claim) throws IOException {
+    @SuppressWarnings("PMD.AvoidCatchingThrowable")
+    public void add(final Iterable<Directive> claim) {
         try (final Item item = this.item()) {
             new Xocument(item).modify(
                 new Directives().xpath("/claims").append(claim)
@@ -128,15 +128,18 @@ public final class Claims {
                     )
                 );
             }
-        }
-        final int size = new LengthOf(this.iterate()).intValue();
-        if (size > Tv.HUNDRED) {
-            throw new IllegalStateException(
-                String.format(
-                    "Can't add, claims overflow in %s, too many items: %d",
-                    this.project.pid(), size
-                )
-            );
+            final int size = new LengthOf(this.iterate()).intValue();
+            if (size > Tv.HUNDRED) {
+                throw new IllegalStateException(
+                    String.format(
+                        "Can't add, claims overflow in %s, too many items: %d",
+                        this.project.pid(), size
+                    )
+                );
+            }
+            // @checkstyle IllegalCatchCheck (1 line)
+        } catch (final Throwable ex) {
+            throw new Claims.AddException(ex);
         }
     }
 
@@ -215,6 +218,24 @@ public final class Claims {
      */
     private Item item() throws IOException {
         return this.project.acq("claims.xml");
+    }
+
+    /**
+     * Exception during claim add.
+     */
+    public static final class AddException extends RuntimeException {
+        /**
+         * Serialization marker.
+         */
+        private static final long serialVersionUID = 9202303101888716333L;
+
+        /**
+         * Constructor.
+         * @param cause The cause of this exception
+         */
+        AddException(final Throwable cause) {
+            super(cause);
+        }
     }
 
 }

--- a/src/test/java/com/zerocracy/farm/StkSafeTest.java
+++ b/src/test/java/com/zerocracy/farm/StkSafeTest.java
@@ -16,7 +16,6 @@
  */
 package com.zerocracy.farm;
 
-import com.jcabi.aspects.Tv;
 import com.jcabi.xml.XML;
 import com.zerocracy.Project;
 import com.zerocracy.SoftException;
@@ -82,18 +81,9 @@ public final class StkSafeTest {
         final Project project = new FkProject();
         new ClaimOut().type("hi").postTo(project);
         final XML claim = new Claims(project).iterate().iterator().next();
-        final RuntimeException exception = Mockito.mock(RuntimeException.class);
-        Mockito.when(exception.getStackTrace()).thenReturn(
-            new StackTraceElement[] {
-                new StackTraceElement(
-                    Claims.class.getCanonicalName(),
-                    "add",
-                    "Claims.java",
-                    Tv.HUNDRED
-                ),
-            }
-        );
-        Mockito.doThrow(exception).when(stk).process(project, claim);
+        Mockito.doThrow(Claims.AddException.class)
+            .when(stk)
+            .process(project, claim);
         MatcherAssert.assertThat(
             new Claims(project).iterate(),
             Matchers.iterableWithSize(1)

--- a/src/test/java/com/zerocracy/pm/ClaimsTest.java
+++ b/src/test/java/com/zerocracy/pm/ClaimsTest.java
@@ -121,7 +121,7 @@ public final class ClaimsTest {
         );
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = Claims.AddException.class)
     public void prohibitsDuplicateClaims() throws Exception {
         final Claims claims = new Claims(new FkProject()).bootstrap();
         final String type = "hello future";


### PR DESCRIPTION
#1245 
- added a check in StkSafe that won't send out `Error` claim if the exception is thrown from `Claims.add` method
- removed todo