### PR TITLE
For #980: 0crat doesn't succeed paying via ethereum

### DIFF
--- a/src/main/java/com/zerocracy/pmo/banks/Crypto.java
+++ b/src/main/java/com/zerocracy/pmo/banks/Crypto.java
@@ -40,6 +40,9 @@ import org.joda.money.Money;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.21
+ * @todo #980:30min We need to drop Etherium support from Zerocracy: Remove ETH
+ *  support mentioned in Policy (§20) and Remove ETH wallets support informing
+ *  that ETH cannot be used when user tries to use it.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 final class Crypto implements Bank {


### PR DESCRIPTION
Result from #980:
We need to drop Etherium support from Zerocracy

Remove ETH support mentioned in Policy (https://www.zerocracy.com/policy.html#20)
Remove ETH wallets support informing that ETH cannot be used when user tries to use it.