### PR TITLE
correcting claim type for set title stk

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pmo/agenda/set_agenda_title_from_github.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pmo/agenda/set_agenda_title_from_github.groovy
@@ -13,8 +13,11 @@ import com.zerocracy.radars.github.Job
 
 def exec(Project project, XML xml) {
   new Assume(project, xml).notPmo()
-  new Assume(project, xml).type('Start order')
+  new Assume(project, xml).type('Agenda was updated')
   ClaimIn claim = new ClaimIn(xml)
+  if (!claim.hasParam('job')) {
+    return
+  }
   String job = claim.param('job')
   if (!job.startsWith('gh:')) {
     return

--- a/src/test/resources/com/zerocracy/bundles/set_agenda_title_from_github/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/set_agenda_title_from_github/claims.xml
@@ -18,7 +18,7 @@ SOFTWARE.
 <claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.37/xsd/pm/claims.xsd" version="0.1" updated="2017-03-27T11:18:09.228Z">
   <claim id="2147483640">
     <created>2017-03-27T11:18:09.228Z</created>
-    <type>Start order</type>
+    <type>Agenda was updated</type>
     <author>manager</author>
     <token>job;gh:test/test#1</token>
     <params>


### PR DESCRIPTION
'set title' stakeholder was attached to `Start order` which happens before the agenda is updated, so it couldn't update the tile in agenda.
Updated it to attach to `Agenda was updated`.
