### PR TITLE
#1166 Handle JSON null user name values in invite_friend.groovy

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pmo/profile/invite_friend.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pmo/profile/invite_friend.groovy
@@ -29,7 +29,6 @@ import com.zerocracy.pm.ClaimIn
 import com.zerocracy.pmo.Exam
 import com.zerocracy.pmo.People
 import javax.json.JsonObject
-import javax.json.JsonValue
 import org.cactoos.text.AbbreviatedText
 
 def exec(Project pmo, XML xml) {
@@ -63,8 +62,7 @@ def exec(Project pmo, XML xml) {
   People people = new People(farm).bootstrap()
   people.invite(login, author)
   String name
-  if (json.containsKey('name')
-    && json.get('name').getValueType == JsonValue.ValueType.STRING) {
+  if (json.getString('name', '')) {
     name = "@${login} (%${json.getString('name')})"
   } else {
     name = "@${login}"

--- a/src/main/groovy/com/zerocracy/stk/pmo/profile/invite_friend.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pmo/profile/invite_friend.groovy
@@ -29,6 +29,7 @@ import com.zerocracy.pm.ClaimIn
 import com.zerocracy.pmo.Exam
 import com.zerocracy.pmo.People
 import javax.json.JsonObject
+import javax.json.JsonValue
 import org.cactoos.text.AbbreviatedText
 
 def exec(Project pmo, XML xml) {
@@ -61,11 +62,18 @@ def exec(Project pmo, XML xml) {
   }
   People people = new People(farm).bootstrap()
   people.invite(login, author)
+  String name
+  if (json.containsKey('name')
+    && json.get('name').getValueType == JsonValue.ValueType.STRING) {
+    name = "@${login} (%${json.getString('name')})"
+  } else {
+    name = "@${login}"
+  }
   claim.reply(
     new Par(
-      'Thanks, @%s (%s) can now work with us,',
+      'Thanks, %s can now work with us,',
       'and you are the mentor, see §1',
-    ).say(login, json.getString('name'))
+    ).say(name)
   ).postTo(pmo)
   claim.copy()
     .type('Notify user')


### PR DESCRIPTION
#1166: In some cases, invite command throws an exception. The problem is that in `invite_friend.groovy`, we are trying to get the user's `name` field (display name) from their JSON. This is not always present, and Github sometimes returns `null` for it. For example:

```json
{
  "login": "KDobarskyi",
  "id": 29274427,
  "node_id": "MDQ6VXNlcjI5Mjc0NDI3",
  "avatar_url": "https://avatars0.githubusercontent.com/u/29274427?v=4",
  "gravatar_id": "",
  "url": "https://api.github.com/users/KDobarskyi",
  "html_url": "https://github.com/KDobarskyi",
  "followers_url": "https://api.github.com/users/KDobarskyi/followers",
  "following_url": "https://api.github.com/users/KDobarskyi/following{/other_user}",
  "gists_url": "https://api.github.com/users/KDobarskyi/gists{/gist_id}",
  "starred_url": "https://api.github.com/users/KDobarskyi/starred{/owner}{/repo}",
  "subscriptions_url": "https://api.github.com/users/KDobarskyi/subscriptions",
  "organizations_url": "https://api.github.com/users/KDobarskyi/orgs",
  "repos_url": "https://api.github.com/users/KDobarskyi/repos",
  "events_url": "https://api.github.com/users/KDobarskyi/events{/privacy}",
  "received_events_url": "https://api.github.com/users/KDobarskyi/received_events",
  "type": "User",
  "site_admin": false,
  "name": null,
  "company": null,
  "blog": "",
  "location": null,
  "email": null,
  "hireable": null,
  "bio": null,
  "public_repos": 0,
  "public_gists": 0,
  "followers": 0,
  "following": 0,
  "created_at": "2017-06-08T09:13:42Z",
  "updated_at": "2018-07-03T00:42:54Z"
}
```

The fix for this is to first check if: 
a) `name` field is present, and 
b) it's of type `STRING`.

If these conditions are present, we show the display name together with the Github username (current behavior).  If not, we only show the username.