### PR TITLE
#1267 Added Stakeholder to compute average speed per person

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pmo/speed/update_person_speed.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pmo/speed/update_person_speed.groovy
@@ -24,6 +24,15 @@ import com.zerocracy.pm.ClaimIn
 import com.zerocracy.pmo.People
 import com.zerocracy.pmo.Speed
 
+/**
+ * Stakeholder that recomputes average speed per user and posts
+ * it to <code>people.xml</code>.
+ * @author Carlos Miranda (miranda.cma@gmail.com)
+ * @version $Id: 14f140fbaae73ab381382eb74e38b9fe18252595 $
+ * @since 0.25
+ * @param project Project
+ * @param xml Claim XML
+ */
 def exec(Project project, XML xml) {
   new Assume(project, xml).type('Speed was updated')
   Farm farm = binding.variables.farm

--- a/src/main/groovy/com/zerocracy/stk/pmo/speed/update_person_speed.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pmo/speed/update_person_speed.groovy
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.stk.pmo.speed
+
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.farm.Assume
+import com.zerocracy.pm.ClaimIn
+import com.zerocracy.pmo.People
+import com.zerocracy.pmo.Speed
+
+def exec(Project project, XML xml) {
+  new Assume(project, xml).type('Speed was updated')
+  Farm farm = binding.variables.farm
+  String login = new ClaimIn(xml).param('login')
+  People people = new People(farm).bootstrap()
+  if (people.exists(login)) {
+    people.speed(
+      login, new Speed(farm, login).bootstrap().avg()
+    )
+  }
+}

--- a/src/main/java/com/zerocracy/pmo/People.java
+++ b/src/main/java/com/zerocracy/pmo/People.java
@@ -731,11 +731,6 @@ public final class People {
      * @param uid User id
      * @param speed Speed
      * @throws IOException If fails
-     * @todo #1121:30min We should periodically compute average speed for each
-     *  person and update it. This stat will be displayed in Team page.
-     *  Probably the most logical time to do this is after "Order was finished"
-     *  claim. We can add this logic to compute_speed.groovy stakeholder. We
-     *  should also add tests for it.
      */
     public void speed(final String uid, final double speed)
         throws IOException {

--- a/src/test/resources/com/zerocracy/bundles/refresh_person_average_speed_on_speed_update/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/refresh_person_average_speed_on_speed_update/_after.groovy
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.refresh_person_average_speed_on_speed_update
+
+import com.jcabi.xml.XML
+import com.zerocracy.Project
+import com.zerocracy.pmo.People
+import org.hamcrest.MatcherAssert
+import org.hamcrest.number.IsCloseTo
+
+def exec(Project project, XML xml) {
+  MatcherAssert.assertThat(
+    new People(binding.variables.farm).bootstrap().speed('carlosmiranda'),
+    new IsCloseTo(20.0, 0.01)
+  )
+}

--- a/src/test/resources/com/zerocracy/bundles/refresh_person_average_speed_on_speed_update/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/refresh_person_average_speed_on_speed_update/_before.groovy
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.refresh_person_average_speed_on_speed_update
+
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.pmo.People
+import com.zerocracy.pmo.Speed
+import org.hamcrest.MatcherAssert
+import org.hamcrest.number.IsCloseTo
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  MatcherAssert.assertThat(
+    new People(farm).bootstrap().speed('carlosmiranda'),
+    new IsCloseTo(0.0, 0.01)
+  )
+  new Speed(farm, 'carlosmiranda').bootstrap().with {
+    add project.pid(), 'gh:test/speed#1', 10L
+    add project.pid(), 'gh:test/speed#2', 20L
+    add project.pid(), 'gh:test/speed#3', 30L
+  }
+}

--- a/src/test/resources/com/zerocracy/bundles/refresh_person_average_speed_on_speed_update/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/refresh_person_average_speed_on_speed_update/claims.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.2/xsd/pm/claims.xsd" version="0.1" updated="2017-03-27T11:18:09.228Z">
+  <claim id="3">
+    <created>2018-06-28T18:00:00.000Z</created>
+    <type>Speed was updated</type>
+    <params>
+      <param name="login">carlosmiranda</param>
+    </params>
+  </claim>
+</claims>

--- a/src/test/resources/com/zerocracy/bundles/refresh_person_average_speed_on_speed_update/people.xml
+++ b/src/test/resources/com/zerocracy/bundles/refresh_person_average_speed_on_speed_update/people.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<people xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.2/xsd/pmo/people.xsd" version="1" updated="2016-12-29T09:03:21.684Z">
+  <person id="carlosmiranda">
+    <mentor>0crat</mentor>
+    <rate>$39</rate>
+    <reputation>1000</reputation>
+    <details>Some details</details>
+    <jobs>0</jobs>
+    <speed>0.0</speed>
+    <projects>1</projects>
+    <wallet bank="paypal">test@paypal.com</wallet>
+    <links/>
+    <vacation>false</vacation>
+    <skills updated="2018-01-01T00:00:00.000Z"/>
+  </person>
+</people>


### PR DESCRIPTION
#1267: Added `update_person_speed.groovy` stakeholder. It watches for `Speed was updated` claim, computes the latest average speed, and stores it in `people.xml`. Added `BundlesTest` case for it.