### PR TITLE
#1269 RbRelease for receiving Github release event

### DIFF
--- a/src/main/java/com/zerocracy/radars/github/RbRelease.java
+++ b/src/main/java/com/zerocracy/radars/github/RbRelease.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.radars.github;
+
+import com.jcabi.github.Github;
+import com.zerocracy.Farm;
+import com.zerocracy.pm.ClaimOut;
+import javax.json.JsonObject;
+
+/**
+ * Release rebound.
+ *
+ * @author Carlos Miranda (miranda.cma@gmail.com)
+ * @version $Id$
+ * @since 0.25
+ * @todo #1269:30min Each time a release is published, we should pay the
+ *  architect a release bonus. Let's create a stakeholder that will react to
+ *  the "Release was published" claim that will do this. See the following:
+ *  https://github.com/zerocracy/farm/issues/1269#issuecomment-402054891
+ *  http://www.zerocracy.com/policy.html#53
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+public final class RbRelease implements Rebound {
+    /**
+     * Release JSON key.
+     */
+    private static final String JSON_KEY = "release";
+
+    @Override
+    public String react(final Farm farm, final Github github,
+        final JsonObject event) {
+        final String answer;
+        if (event.containsKey(RbRelease.JSON_KEY)) {
+            final JsonObject release = event.getJsonObject(RbRelease.JSON_KEY);
+            new ClaimOut()
+                .type("Release was published")
+                .param("tag", release.getString("tag_name"))
+                .param("date", release.getString("published_at"));
+            answer = String.format(
+                "Release published: %d",
+                release.getInt("id")
+            );
+        } else {
+            answer = "Not a release event";
+        }
+        return answer;
+    }
+}

--- a/src/main/java/com/zerocracy/radars/github/RbRelease.java
+++ b/src/main/java/com/zerocracy/radars/github/RbRelease.java
@@ -26,14 +26,13 @@ import javax.json.JsonObject;
  *
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
- * @since 0.25
+ * @since 0.26
  * @todo #1269:30min Each time a release is published, we should pay the
  *  architect a release bonus. Let's create a stakeholder that will react to
  *  the "Release was published" claim that will do this. See the following:
  *  https://github.com/zerocracy/farm/issues/1269#issuecomment-402054891
  *  http://www.zerocracy.com/policy.html#53
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class RbRelease implements Rebound {
     /**
      * Release JSON key.
@@ -46,13 +45,15 @@ public final class RbRelease implements Rebound {
         final String answer;
         if (event.containsKey(RbRelease.JSON_KEY)) {
             final JsonObject release = event.getJsonObject(RbRelease.JSON_KEY);
+            final String tag = release.getString("tag_name");
             new ClaimOut()
                 .type("Release was published")
-                .param("tag", release.getString("tag_name"))
+                .param("tag", tag)
                 .param("date", release.getString("published_at"));
             answer = String.format(
-                "Release published: %d",
-                release.getInt("id")
+                "Release published: %d (tag: %s)",
+                release.getInt("id"),
+                tag
             );
         } else {
             answer = "Not a release event";

--- a/src/main/java/com/zerocracy/radars/github/TkGithub.java
+++ b/src/main/java/com/zerocracy/radars/github/TkGithub.java
@@ -124,7 +124,8 @@ public final class TkGithub implements Take, Runnable {
                                         "labeled"
                                     ),
                                     new RbByActions(new RbOnAssign(), "assigned"),
-                                    new RbByActions(new RbOnUnassign(), "unassigned")
+                                    new RbByActions(new RbOnUnassign(), "unassigned"),
+                                    new RbByActions(new RbRelease(), "published")
                                 )
                             )
                         )

--- a/src/test/java/com/zerocracy/radars/github/RbReleaseTest.java
+++ b/src/test/java/com/zerocracy/radars/github/RbReleaseTest.java
@@ -27,12 +27,14 @@ import org.junit.Test;
  * Test case for {@link RbRelease}.
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
- * @since 0.25
+ * @since 0.26
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class RbReleaseTest {
     @Test
     public void acceptsRelease() throws Exception {
+        final int id = 1;
+        final String tag = "0.0.1";
         MatcherAssert.assertThat(
             new RbRelease().react(
                 new FkFarm(),
@@ -41,13 +43,17 @@ public final class RbReleaseTest {
                     .add(
                         "release",
                         Json.createObjectBuilder()
-                            .add("tag_name", "0.0.1")
-                            .add("id", 1)
+                            .add("tag_name", tag)
+                            .add("id", id)
                             .add("published_at", "2018-04-06T07:00:00Z")
                             .build()
                     ).build()
             ),
-            Matchers.startsWith("Release published: 1")
+            Matchers.is(
+                String.format(
+                    "Release published: %d (tag: %s)", id, tag
+                )
+            )
         );
     }
 }

--- a/src/test/java/com/zerocracy/radars/github/RbReleaseTest.java
+++ b/src/test/java/com/zerocracy/radars/github/RbReleaseTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.radars.github;
+
+import com.jcabi.github.mock.MkGithub;
+import com.zerocracy.farm.fake.FkFarm;
+import javax.json.Json;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link RbRelease}.
+ * @author Carlos Miranda (miranda.cma@gmail.com)
+ * @version $Id$
+ * @since 0.25
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class RbReleaseTest {
+    @Test
+    public void acceptsRelease() throws Exception {
+        MatcherAssert.assertThat(
+            new RbRelease().react(
+                new FkFarm(),
+                new MkGithub(),
+                Json.createObjectBuilder()
+                    .add(
+                        "release",
+                        Json.createObjectBuilder()
+                            .add("tag_name", "0.0.1")
+                            .add("id", 1)
+                            .add("published_at", "2018-04-06T07:00:00Z")
+                            .build()
+                    ).build()
+            ),
+            Matchers.startsWith("Release published: 1")
+        );
+    }
+}


### PR DESCRIPTION
#1269: Added `RbRelease` to receive Github [release event](https://developer.github.com/v3/activity/events/types/#releaseevent). This `Rebound` implementation responds to `published` Github action, and generates a claim `Release was published`.

Added puzzle for further implementation of stakeholder that responds to the claim in order to pay the [architect release bonus](http://www.zerocracy.com/policy.html#53).