### PR TITLE
Don't resubmit error claims

### DIFF
--- a/src/main/java/com/zerocracy/farm/StkSafe.java
+++ b/src/main/java/com/zerocracy/farm/StkSafe.java
@@ -35,8 +35,12 @@ import org.cactoos.text.TextOf;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.1
+ * @checkstyle CyclomaticComplexityCheck (500 lines)
  */
 @EqualsAndHashCode(of = "identifier")
+@SuppressWarnings(
+    {"PMD.ModifiedCyclomaticComplexity", "PMD.StdCyclomaticComplexity"}
+)
 public final class StkSafe implements Stakeholder {
 
     /**
@@ -119,13 +123,15 @@ public final class StkSafe implements Stakeholder {
             if (props.has("//testing")) {
                 throw new IllegalStateException(ex);
             }
-            claim.copy()
-                .type("Error")
-                .param("origin_id", claim.cid())
-                .param("origin_type", claim.type())
-                .param("message", msg.toString())
-                .param("stacktrace", StkSafe.stacktrace(ex))
-                .postTo(project);
+            if (!claim.isError()) {
+                claim.copy()
+                    .type("Error")
+                    .param("origin_id", claim.cid())
+                    .param("origin_type", claim.type())
+                    .param("message", msg.toString())
+                    .param("stacktrace", StkSafe.stacktrace(ex))
+                    .postTo(project);
+            }
             Sentry.capture(ex);
             if (claim.hasToken() && !claim.type().startsWith("Notify")) {
                 claim.reply(

--- a/src/main/java/com/zerocracy/pm/ClaimIn.java
+++ b/src/main/java/com/zerocracy/pm/ClaimIn.java
@@ -35,7 +35,7 @@ import org.cactoos.time.DateOf;
  * @version $Id$
  * @since 0.9
  */
-@SuppressWarnings({ "PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods" })
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 public final class ClaimIn {
 
     /**
@@ -121,6 +121,14 @@ public final class ClaimIn {
      */
     public String type() {
         return this.xml.xpath("type/text()").get(0);
+    }
+
+    /**
+     * Is this claim error.
+     * @return True if error
+     */
+    public boolean isError() {
+        return "Error".equals(this.type());
     }
 
     /**

--- a/src/main/java/com/zerocracy/pm/Claims.java
+++ b/src/main/java/com/zerocracy/pm/Claims.java
@@ -49,10 +49,6 @@ import org.xembly.Xembler;
  *  a project if this size is too big. We can skip downloading from S3,
  *  just need to check attributes, and if claims.xml is bigger than 10MB
  *  stop working with this project and send notification to PMO.
- * @todo #1307:30min Changes for #1245 fix were reverted in
- *  a2f5821c23469a680485ae8bb6ac875316eb3b24 because they produces
- *  #1307 bug: some claims may be missed and never added
- *  to claims.xml, so 0crat lose Github or chat actions.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class Claims {

--- a/src/test/java/com/zerocracy/farm/StkSafeTest.java
+++ b/src/test/java/com/zerocracy/farm/StkSafeTest.java
@@ -26,6 +26,7 @@ import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pm.ClaimOut;
 import com.zerocracy.pm.Claims;
 import java.io.IOException;
+import org.cactoos.iterable.LengthOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -77,15 +78,19 @@ public final class StkSafeTest {
     public void dontRepeatErrorClaims() throws Exception {
         final FkProject project = new FkProject();
         new ClaimOut().type("Error").postTo(project);
-        final XML claim = new Claims(project).iterate().iterator().next();
+        final int before = new LengthOf(new Claims(project).iterate())
+            .intValue();
         new StkSafe(
             "errors1",
             new StkSafeTest.NonTestingFarm(),
             new StkSafeTest.StkError()
-        ).process(project, claim);
+        ).process(
+            project,
+            new Claims(project).iterate().iterator().next()
+        );
         MatcherAssert.assertThat(
             new Claims(project).iterate(),
-            Matchers.iterableWithSize(1)
+            Matchers.iterableWithSize(before)
         );
     }
 
@@ -113,20 +118,9 @@ public final class StkSafeTest {
          * Ctor.
          */
         NonTestingFarm() {
-            this(
-                new PropsFarm(
-                    new Directives().xpath("/props/testing").remove()
-                )
+            this.frm = new PropsFarm(
+                new Directives().xpath("/props/testing").remove()
             );
-        }
-
-        /**
-         * Ctor.
-         *
-         * @param farm Farm
-         */
-        private NonTestingFarm(final Farm farm) {
-            this.frm = farm;
         }
 
         @Override

--- a/src/test/java/com/zerocracy/pm/ClaimInTest.java
+++ b/src/test/java/com/zerocracy/pm/ClaimInTest.java
@@ -17,6 +17,7 @@
 package com.zerocracy.pm;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -36,9 +37,9 @@ public final class ClaimInTest {
     @Test
     public void readsParts() throws Exception {
         final ClaimIn claim = new ClaimIn(
-            new XMLDocument(
+            ClaimInTest.claim(
                 "<claim id='1'><author>yegor256</author></claim>"
-            ).nodes("/claim").get(0)
+            )
         );
         MatcherAssert.assertThat(
             claim.author(),
@@ -49,13 +50,13 @@ public final class ClaimInTest {
     @Test
     public void buildsClaimOut() throws Exception {
         final ClaimIn claim = new ClaimIn(
-            new XMLDocument(
+            ClaimInTest.claim(
                 String.join(
                     "",
                     "<claim id='1'><type>ZZ</type>",
                     "<author>jeff</author><token>X</token></claim>"
                 )
-            ).nodes("/claim ").get(0)
+            )
         );
         MatcherAssert.assertThat(
             XhtmlMatchers.xhtml(
@@ -77,7 +78,7 @@ public final class ClaimInTest {
     @Test
     public void makesCopy() throws Exception {
         final ClaimIn claim = new ClaimIn(
-            new XMLDocument(
+            ClaimInTest.claim(
                 String.join(
                     "",
                     "<claim id='1'><author>yegor</author> ",
@@ -85,7 +86,7 @@ public final class ClaimInTest {
                     "<token>the-token</token> ",
                     "<params><param name='a'>hello</param></params></claim>"
                 )
-            ).nodes("/claim   ").get(0)
+            )
         );
         MatcherAssert.assertThat(
             XhtmlMatchers.xhtml(
@@ -103,4 +104,22 @@ public final class ClaimInTest {
         );
     }
 
+    @Test
+    public void errorClaim() throws Exception {
+        MatcherAssert.assertThat(
+            new ClaimIn(
+                ClaimInTest.claim("<claim id='1'><type>Error</type></claim>")
+            ).isError(),
+            Matchers.is(true)
+        );
+    }
+
+    /**
+     * Claim from text.
+     * @param xml XML text
+     * @return Claim
+     */
+    private static XML claim(final String xml) {
+        return new XMLDocument(xml).nodes("/claim").get(0);
+    }
 }


### PR DESCRIPTION
#1317 - do not submit `Error` claims in `StkSafe` if reason was another `Error` claim