### PR TITLE
#1088 included groovy scripts in jacoco coverage

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
 build_script:
   - mvn clean package -B -Dmaven.test.skip=true
 test_script:
-  - mvn clean install --batch-mode -Pqulice -Dbranch.coverage=0.51
+  - mvn clean install --batch-mode -Pqulice -Dbranch.coverage=0.44
 cache:
   - C:\maven\
   - C:\Users\appveyor\.m2

--- a/pom.xml
+++ b/pom.xml
@@ -503,7 +503,7 @@ SOFTWARE.
                       <limit>
                         <counter>COMPLEXITY</counter>
                         <value>COVEREDRATIO</value>
-                        <minimum>0.46</minimum>
+                        <minimum>0.45</minimum>
                       </limit>
                       <limit>
                         <counter>METHOD</counter>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@ SOFTWARE.
   <properties>
     <mongo.version>3.8.0</mongo.version>
     <telegram.version>3.6</telegram.version>
-    <branch.coverage>0.52</branch.coverage>
+    <branch.coverage>0.45</branch.coverage>
   </properties>
   <dependencies>
     <dependency>
@@ -476,7 +476,7 @@ SOFTWARE.
                       <limit>
                         <counter>INSTRUCTION</counter>
                         <value>COVEREDRATIO</value>
-                        <minimum>0.60</minimum>
+                        <minimum>0.58</minimum>
                       </limit>
                       <limit>
                         <counter>LINE</counter>
@@ -488,6 +488,13 @@ SOFTWARE.
                           branch coverage of 65% and class missed count of max 15.
                           Remember to increase those coverages below in jacoco configuration.
                       -->
+                      <!-- 
+                           @todo #1088:30min Groovy scripts are now not excluded, as a result
+                            complexity coverage ration dropped from 0.57, and instruction
+                            coverage dropped from 0.60. Add tests to
+                            stakeholder scripts to the previous coverage of 0.57 for
+                            complexity and 0.60 for instruction coverage.
+                       -->
                       <limit>
                         <counter>BRANCH</counter>
                         <value>COVEREDRATIO</value>
@@ -496,7 +503,7 @@ SOFTWARE.
                       <limit>
                         <counter>COMPLEXITY</counter>
                         <value>COVEREDRATIO</value>
-                        <minimum>0.57</minimum>
+                        <minimum>0.46</minimum>
                       </limit>
                       <limit>
                         <counter>METHOD</counter>
@@ -506,19 +513,11 @@ SOFTWARE.
                       <limit>
                         <counter>CLASS</counter>
                         <value>MISSEDCOUNT</value>
-                        <maximum>60</maximum>
+                        <maximum>68</maximum>
                       </limit>
                     </limits>
                   </rule>
                 </rules>
-                <excludes combine.children="append">
-                  <!--
-                    @todo #747:30min Groovy scripts are excluded from coverage report
-                     because they are not fully tested. Let's add tests for them and remove this
-                     `<exclude>` line.
-                  -->
-                  <exclude>com/zerocracy/stk/**/*</exclude>
-                </excludes>
               </configuration>
             </execution>
             <execution>

--- a/src/test/resources/com/zerocracy/bundles/changes_user_rate/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/changes_user_rate/_after.groovy
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.changes_user_rate
+
+import com.jcabi.xml.XML
+import com.zerocracy.Project
+import com.zerocracy.pm.cost.Rates
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+def exec(Project project, XML xml) {
+  MatcherAssert.assertThat(
+    new Rates(project).rate('user42').decimal().doubleValue(),
+    Matchers.equalTo(100.0D)
+  )
+}

--- a/src/test/resources/com/zerocracy/bundles/changes_user_rate/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/changes_user_rate/_after.groovy
@@ -24,7 +24,7 @@ import org.hamcrest.Matchers
 
 def exec(Project project, XML xml) {
   MatcherAssert.assertThat(
-    new Rates(project).rate('user42').decimal().doubleValue(),
+    new Rates(project).bootstrap().rate('user42').decimal().doubleValue(),
     Matchers.equalTo(100.0D)
   )
 }

--- a/src/test/resources/com/zerocracy/bundles/changes_user_rate/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/changes_user_rate/_before.groovy
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.changes_user_rate
+
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.pmo.People
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  People people = new People(farm).bootstrap()
+  String user = 'user42'
+  people.wallet(user, 'paypal', 'user@example.com')
+  people.details(user, 'something')
+}

--- a/src/test/resources/com/zerocracy/bundles/changes_user_rate/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/changes_user_rate/_before.groovy
@@ -19,12 +19,21 @@ package com.zerocracy.bundles.changes_user_rate
 import com.jcabi.xml.XML
 import com.zerocracy.Farm
 import com.zerocracy.Project
+import com.zerocracy.cash.Cash
+import com.zerocracy.pm.cost.Rates
 import com.zerocracy.pmo.People
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
 
 def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
   People people = new People(farm).bootstrap()
   String user = 'user42'
   people.wallet(user, 'paypal', 'user@example.com')
-  people.details(user, 'something')
+  Rates rates = new Rates(project).bootstrap()
+  rates.set(user, new Cash.S('$10'))
+  MatcherAssert.assertThat(
+    rates.rate(user).decimal().doubleValue(),
+    Matchers.equalTo(10.0D)
+  )
 }

--- a/src/test/resources/com/zerocracy/bundles/changes_user_rate/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/changes_user_rate/claims.xml
@@ -17,7 +17,7 @@ SOFTWARE.
 -->
 <claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.28/xsd/pm/claims.xsd" updated="2017-07-21T20:31:44.512Z" version="1">
   <claim id="1">
-    <created>2017-07-21T20:32:19.716Z</created>
+    <created>2018-07-07T20:32:19.716Z</created>
     <type>Change user rate</type>
     <token>test;C123;user42</token>
     <author>g4s8</author>

--- a/src/test/resources/com/zerocracy/bundles/changes_user_rate/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/changes_user_rate/claims.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.28/xsd/pm/claims.xsd" updated="2017-07-21T20:31:44.512Z" version="1">
+  <claim id="1">
+    <created>2017-07-21T20:32:19.716Z</created>
+    <type>Change user rate</type>
+    <token>test;C123;user42</token>
+    <author>g4s8</author>
+    <params>
+      <param name="login">user42</param>
+      <param name="rate">$100</param>
+    </params>
+  </claim>
+</claims>

--- a/src/test/resources/com/zerocracy/bundles/changes_user_rate/people.xml
+++ b/src/test/resources/com/zerocracy/bundles/changes_user_rate/people.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<people xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.28/xsd/pmo/people.xsd" version="1" updated="2016-12-29T09:03:21.684Z">
+  <person id="user42">
+    <mentor>g4s8</mentor>
+  </person>
+  <person id="g4s8">
+    <mentor>0crat</mentor>
+  </person>
+</people>

--- a/src/test/resources/com/zerocracy/bundles/changes_user_rate/roles.xml
+++ b/src/test/resources/com/zerocracy/bundles/changes_user_rate/roles.xml
@@ -19,7 +19,4 @@ SOFTWARE.
   <person id="g4s8">
     <role>ARC</role>
   </person>
-  <person id="user42">
-    <role>DEV</role>
-  </person>
 </roles>

--- a/src/test/resources/com/zerocracy/bundles/changes_user_rate/roles.xml
+++ b/src/test/resources/com/zerocracy/bundles/changes_user_rate/roles.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<roles xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.33/xsd/pm/staff/roles.xsd" version="0.1" updated="2017-08-07T10:37:00.000Z">
+  <person id="g4s8">
+    <role>ARC</role>
+  </person>
+  <person id="user42">
+    <role>DEV</role>
+  </person>
+</roles>


### PR DESCRIPTION
#1088 
* removed exclusion for groovy scripts
* decreased coverages so the build passes (this will stop the coverage to drop)
* added todo to add more tests for stakeholders and increase the coverage
* added a missing test for changing of user rate