### PR TITLE
#1265 fix multi-currency estimates

### DIFF
--- a/src/main/java/com/zerocracy/cash/Cash.java
+++ b/src/main/java/com/zerocracy/cash/Cash.java
@@ -106,7 +106,16 @@ public interface Cash extends Comparable<Cash>, Serializable {
     Cash exchange(Currency currency) throws IOException;
 
     /**
-     * Is cash representation unified?
+     * Is cash representation unified (there were no {@code add} method called)?
+     *
+     * Non-unified Cash object is created by doing {@link #add(Cash)} of
+     * {@code Cash} objects:
+     * <pre>
+     *     Cash cash = new Cash.S("$10").add(new Cash.S("$20"));
+     * </pre>
+     *
+     * To get a unified {@code Cash} object you need to call
+     * {@link #exchange(Currency)} method.
      * @return True if the cash has been unified.
      */
     boolean unified();

--- a/src/main/java/com/zerocracy/cash/Cash.java
+++ b/src/main/java/com/zerocracy/cash/Cash.java
@@ -106,6 +106,12 @@ public interface Cash extends Comparable<Cash>, Serializable {
     Cash exchange(Currency currency) throws IOException;
 
     /**
+     * Is cash representation unified?
+     * @return True if the cash has been unified.
+     */
+    boolean unified();
+
+    /**
      * Simple implementation.
      */
     @EqualsAndHashCode(of = "pairs")
@@ -235,7 +241,7 @@ public interface Cash extends Comparable<Cash>, Serializable {
 
         @Override
         public BigDecimal decimal() {
-            if (this.pairs.length != 1) {
+            if (!this.unified()) {
                 throw new IllegalStateException(
                     String.format(
                         "Use exchange() first to unify currencies: \"%s\"",
@@ -268,6 +274,11 @@ public interface Cash extends Comparable<Cash>, Serializable {
                 prs[num] = this.pairs[num].exchange(currency, this.qts);
             }
             return new Cash.S(prs, this.qts);
+        }
+
+        @Override
+        public boolean unified() {
+            return this.pairs.length == 1;
         }
 
         /**

--- a/src/main/java/com/zerocracy/pm/cost/Estimates.java
+++ b/src/main/java/com/zerocracy/pm/cost/Estimates.java
@@ -163,26 +163,27 @@ public final class Estimates {
                     .add("cash")
                     .set(cash)
             );
+            final Cash value = new IoCheckedScalar<>(
+                new Ternary<>(
+                    new IoCheckedScalar<>(
+                        new Reduced<Cash, Cash>(
+                            Cash.ZERO,
+                            Cash::add,
+                            new Mapped<>(
+                                Cash.S::new,
+                                xoc.xpath("//order/cash/text()")
+                            )
+                        )
+                    ).value(),
+                    Cash::unified,
+                    csh -> csh,
+                    csh -> csh.exchange(Currency.USD)
+                )
+            ).value();
             xoc.modify(
                 new Directives().xpath("/estimates").attr(
                     "total",
-                    new IoCheckedScalar<>(
-                        new Ternary<>(
-                            new IoCheckedScalar<>(
-                                new Reduced<Cash, Cash>(
-                                    Cash.ZERO,
-                                    Cash::add,
-                                    new Mapped<>(
-                                        Cash.S::new,
-                                        xoc.xpath("//order/cash/text()")
-                                    )
-                                )
-                            ).value(),
-                            Cash::unified,
-                            first -> first,
-                            second -> second.exchange(Currency.USD)
-                        )
-                    ).value()
+                    value
                 )
             );
         }

--- a/src/main/java/com/zerocracy/pm/cost/Estimates.java
+++ b/src/main/java/com/zerocracy/pm/cost/Estimates.java
@@ -23,6 +23,7 @@ import com.zerocracy.SoftException;
 import com.zerocracy.Xocument;
 import com.zerocracy.cash.Cash;
 import com.zerocracy.cash.CashParsingException;
+import com.zerocracy.cash.Currency;
 import com.zerocracy.pm.in.Orders;
 import com.zerocracy.pm.scope.Wbs;
 import com.zerocracy.pm.staff.Roles;
@@ -32,6 +33,7 @@ import java.util.LinkedList;
 import org.cactoos.collection.Mapped;
 import org.cactoos.scalar.IoCheckedScalar;
 import org.cactoos.scalar.Reduced;
+import org.cactoos.scalar.Ternary;
 import org.cactoos.time.DateAsText;
 import org.xembly.Directives;
 
@@ -165,13 +167,20 @@ public final class Estimates {
                 new Directives().xpath("/estimates").attr(
                     "total",
                     new IoCheckedScalar<>(
-                        new Reduced<Cash, Cash>(
-                            Cash.ZERO,
-                            Cash::add,
-                            new Mapped<>(
-                                Cash.S::new,
-                                xoc.xpath("//order/cash/text()")
-                            )
+                        new Ternary<>(
+                            new IoCheckedScalar<>(
+                                new Reduced<Cash, Cash>(
+                                    Cash.ZERO,
+                                    Cash::add,
+                                    new Mapped<>(
+                                        Cash.S::new,
+                                        xoc.xpath("//order/cash/text()")
+                                    )
+                                )
+                            ).value(),
+                            Cash::unified,
+                            first -> first,
+                            second -> second.exchange(Currency.USD)
                         )
                     ).value()
                 )

--- a/src/test/java/com/zerocracy/pm/cost/EstimatesTest.java
+++ b/src/test/java/com/zerocracy/pm/cost/EstimatesTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
  * @since 0.10
  * @checkstyle JavadocMethodCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class EstimatesTest {
 
     @Test
@@ -70,6 +71,36 @@ public final class EstimatesTest {
         MatcherAssert.assertThat(
             estimates.total(),
             Matchers.equalTo(new Cash.S("$145.00"))
+        );
+    }
+
+    @Test
+    public void estimatesJobsWithDifferentCurrencies() throws Exception {
+        final Project project = new FkProject();
+        new Ledger(project).bootstrap().add(
+            new Ledger.Transaction(
+                new Cash.S("$500"),
+                "assets", "cash",
+                "income", "sponsor",
+                "Funded by some guy"
+            )
+        );
+        final Estimates estimates = new Estimates(project).bootstrap();
+        final String first = "gh:yegor256/pdd#4";
+        new Wbs(project).bootstrap().add(first);
+        new Orders(project).bootstrap().assign(first, "yegor256", 0L);
+        estimates.update(first, new Cash.S("$45"));
+        MatcherAssert.assertThat(
+            estimates.get(first),
+            Matchers.equalTo(new Cash.S("$45.00"))
+        );
+        final String second = "gh:yegor256/pdd#1";
+        new Wbs(project).bootstrap().add(second);
+        new Orders(project).bootstrap().assign(second, "yegor", 0L);
+        estimates.update(second, new Cash.S("€100"));
+        MatcherAssert.assertThat(
+            estimates.total(),
+            Matchers.equalTo(new Cash.S("$177.00"))
         );
     }
 

--- a/src/test/java/com/zerocracy/pm/cost/EstimatesTest.java
+++ b/src/test/java/com/zerocracy/pm/cost/EstimatesTest.java
@@ -87,7 +87,8 @@ public final class EstimatesTest {
         );
         final Estimates estimates = new Estimates(project).bootstrap();
         final String first = "gh:yegor256/pdd#4";
-        new Wbs(project).bootstrap().add(first);
+        final Wbs wbs = new Wbs(project).bootstrap();
+        wbs.add(first);
         new Orders(project).bootstrap().assign(first, "yegor256", 0L);
         estimates.update(first, new Cash.S("$45"));
         MatcherAssert.assertThat(
@@ -95,7 +96,7 @@ public final class EstimatesTest {
             Matchers.equalTo(new Cash.S("$45.00"))
         );
         final String second = "gh:yegor256/pdd#1";
-        new Wbs(project).bootstrap().add(second);
+        wbs.add(second);
         new Orders(project).bootstrap().assign(second, "yegor", 0L);
         estimates.update(second, new Cash.S("€100"));
         MatcherAssert.assertThat(


### PR DESCRIPTION
#1265 
* added a check in `Estimates` if the `Cash` object is unified (contains single currency) and if not then do an exchange to USD
* added `unified` method to `Cash`