### PR TITLE
#1016 Impediments.remove(...) + unit test and puzzle

### DIFF
--- a/src/main/resources/com/zerocracy/radars/q-tracker.xml
+++ b/src/main/resources/com/zerocracy/radars/q-tracker.xml
@@ -81,6 +81,13 @@ SOFTWARE.
     <invited>false</invited>
   </cmd>
   <cmd>
+    <code>Remove impediment</code>
+    <regex>continue</regex>
+    <label>continue</label>
+    <help>Remove a job's impediment</help>
+    <invited>false</invited>
+  </cmd>
+  <cmd>
     <code>Check job status</code>
     <regex>status|check</regex>
     <label>status</label>

--- a/src/test/java/com/zerocracy/pm/in/ImpedimentsTest.java
+++ b/src/test/java/com/zerocracy/pm/in/ImpedimentsTest.java
@@ -17,6 +17,7 @@
 package com.zerocracy.pm.in;
 
 import com.zerocracy.Project;
+import com.zerocracy.SoftException;
 import com.zerocracy.farm.fake.FkProject;
 import com.zerocracy.pm.scope.Wbs;
 import org.hamcrest.MatcherAssert;
@@ -76,5 +77,11 @@ public final class ImpedimentsTest {
             imp.exists(job),
             Matchers.is(false)
         );
+    }
+
+    @Test(expected = SoftException.class)
+    public void removesMissingImpediment() throws Exception {
+        final Impediments imp = new Impediments(new FkProject()).bootstrap();
+        imp.remove("gh:test/test#8");
     }
 }

--- a/src/test/java/com/zerocracy/pm/in/ImpedimentsTest.java
+++ b/src/test/java/com/zerocracy/pm/in/ImpedimentsTest.java
@@ -50,4 +50,31 @@ public final class ImpedimentsTest {
             Matchers.is(true)
         );
     }
+
+    @Test
+    public void removesImpediment() throws Exception {
+        final Project project = new FkProject();
+        final Impediments imp = new Impediments(project).bootstrap();
+        final String job = "gh:test/test#2";
+        new Wbs(project).bootstrap().add(job);
+        new Orders(project).bootstrap().assign(job, "amihaiemil", 0L);
+        imp.register(job, "reason");
+        MatcherAssert.assertThat(
+            imp.jobs(),
+            Matchers.contains(job)
+        );
+        MatcherAssert.assertThat(
+            imp.exists(job),
+            Matchers.is(true)
+        );
+        imp.remove(job);
+        MatcherAssert.assertThat(
+            imp.jobs(),
+            Matchers.not(Matchers.contains(job))
+        );
+        MatcherAssert.assertThat(
+            imp.exists(job),
+            Matchers.is(false)
+        );
+    }
 }


### PR DESCRIPTION
PR for #1016 

* Registered the ``continue`` command inside ``q-tracker.xml``
* Added method ``Impediments.remove(...)``
* Added unit test for ``Impediments.remove(...)``
* Left puzzle for continuing implementation of the stakeholder.