### PR TITLE
#1123 Re-enable Jobs and Agenda display in Team page

### DIFF
--- a/src/main/java/com/zerocracy/tk/TkTeam.java
+++ b/src/main/java/com/zerocracy/tk/TkTeam.java
@@ -42,10 +42,7 @@ import org.takes.rs.xe.XeWhen;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.19
- * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @todo #1121:30min Speed and Agenda is skipped now because it
- *  causes slow page loading. We have to fix #1121 bug and show
- *  it on page as before.
+ * @checkstyle ClassDataAbstractionCouplingCheck (3 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class TkTeam implements Take {
@@ -100,8 +97,8 @@ public final class TkTeam implements Take {
                 new XeAppend("login", node.xpath("@id").get(0)),
                 new XeAppend("mentor", node.xpath("mentor/text()").get(0)),
                 new XeAppend("awards", node.xpath("reputation/text()").get(0)),
-                new XeAppend("speed", "0.0"),
-                new XeAppend("agenda", "-"),
+                new XeAppend("speed", node.xpath("speed/text()").get(0)),
+                new XeAppend("agenda", node.xpath("jobs/text()").get(0)),
                 new XeAppend(
                     "projects",
                     Integer.toString(

--- a/src/test/java/com/zerocracy/tk/TkTeamTest.java
+++ b/src/test/java/com/zerocracy/tk/TkTeamTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.tk;
+
+import com.jcabi.aspects.Tv;
+import com.jcabi.matchers.XhtmlMatchers;
+import com.zerocracy.Farm;
+import com.zerocracy.farm.fake.FkFarm;
+import com.zerocracy.farm.props.PropsFarm;
+import com.zerocracy.pmo.People;
+import java.io.IOException;
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+import org.takes.rq.RqFake;
+import org.takes.rs.RsPrint;
+
+/**
+ * Test case for {@link TkTeam}.
+ * @author Carlos Miranda (miranda.cma@gmail.com)
+ * @version $Id$
+ * @since 0.26
+ * @checkstyle JavadocMethod (500 lines)
+ * @checkstyle MagicNumber (500 lines)
+ * @checkstyle ClassDataAbstractionCoupling (3 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+public final class TkTeamTest {
+
+    @Test
+    public void showsSpeedInDays() throws Exception {
+        final Farm farm = new PropsFarm(new FkFarm());
+        final People people = new People(farm).bootstrap();
+        final String user = "yegor256";
+        people.touch(user);
+        people.speed(user, 2880.0);
+        MatcherAssert.assertThat(
+            XhtmlMatchers.xhtml(this.responseBody(farm)),
+            XhtmlMatchers.hasXPaths(
+                String.format("//xhtml:td[.='%s']", 2.0)
+            )
+        );
+    }
+
+    @Test
+    public void showsNumberOfJobsInAgenda() throws Exception {
+        final Farm farm = new PropsFarm(new FkFarm());
+        final People people = new People(farm).bootstrap();
+        final String user = "yegor256";
+        people.touch(user);
+        people.jobs(user, Tv.TEN);
+        MatcherAssert.assertThat(
+            XhtmlMatchers.xhtml(this.responseBody(farm)),
+            XhtmlMatchers.hasXPaths(
+                String.format("//xhtml:td[.='%s']", Tv.TEN)
+            )
+        );
+    }
+
+    private String responseBody(final Farm farm) throws IOException {
+        return new RsPrint(
+            new TkApp(farm).act(
+                new RqWithUser(
+                    farm,
+                    new RqFake(
+                        new ListOf<>(
+                            "GET /team",
+                            "Host: www.example.com"
+                        ),
+                        ""
+                    )
+                )
+            )
+        ).printBody();
+    }
+}


### PR DESCRIPTION
#1123 After the fixes in #841 and #1267, speed and agenda data for users are now stored in `people.xml` ("jobs" element for agenda) instead of being computed on each page load. This fix will display those elements on the Teams page.