### PR TITLE
Soft references for caching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,13 @@ SOFTWARE.
     <telegram.version>3.6</telegram.version>
     <branch.coverage>0.45</branch.coverage>
   </properties>
+  <repositories>
+    <repository>
+      <id>bintray-g4s8-maven</id>
+      <name>bintray-g4s8-maven</name>
+      <url>https://dl.bintray.com/g4s8/mvn</url>
+    </repository>
+  </repositories>
   <dependencies>
     <dependency>
       <groupId>org.cactoos</groupId>
@@ -416,6 +423,11 @@ SOFTWARE.
       <artifactId>postgresql</artifactId>
       <version>42.2.2</version>
       <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.g4s8</groupId>
+      <artifactId>cactoos-cache</artifactId>
+      <version>0.1.3</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/com/zerocracy/Xocument.java
+++ b/src/main/java/com/zerocracy/Xocument.java
@@ -34,7 +34,8 @@ import java.util.LinkedList;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.cactoos.Scalar;
-import org.cactoos.func.SolidFunc;
+import org.cactoos.cache.SoftFunc;
+import org.cactoos.func.SyncFunc;
 import org.cactoos.func.UncheckedFunc;
 import org.cactoos.io.InputOf;
 import org.cactoos.io.InputStreamOf;
@@ -74,14 +75,16 @@ public final class Xocument {
      * Cache of documents.
      */
     private static final UncheckedFunc<URL, XML> INDEXES = new UncheckedFunc<>(
-        new SolidFunc<>(
-            url -> new XMLDocument(
-                new TextOf(
-                    new InputWithFallback(
-                        new InputOf(url),
-                        new InputOf("<index/>")
-                    )
-                ).asString()
+        new SyncFunc<>(
+            new SoftFunc<>(
+                url -> new XMLDocument(
+                    new TextOf(
+                        new InputWithFallback(
+                            new InputOf(url),
+                            new InputOf("<index/>")
+                        )
+                    ).asString()
+                )
             )
         )
     );

--- a/src/main/java/com/zerocracy/farm/ruled/RdAuto.java
+++ b/src/main/java/com/zerocracy/farm/ruled/RdAuto.java
@@ -28,7 +28,8 @@ import java.nio.file.Path;
 import org.apache.commons.lang3.StringUtils;
 import org.cactoos.Func;
 import org.cactoos.Input;
-import org.cactoos.func.SolidFunc;
+import org.cactoos.cache.SoftFunc;
+import org.cactoos.func.SyncFunc;
 import org.cactoos.func.UncheckedFunc;
 import org.cactoos.io.InputOf;
 import org.cactoos.io.LengthOf;
@@ -53,9 +54,11 @@ final class RdAuto {
      * Cache of documents.
      */
     private static final UncheckedFunc<URI, Input> CACHE = new UncheckedFunc<>(
-        new SolidFunc<>(
-            (Func<URI, Input>) uri -> new SyncInput(
-                new StickyInput(new InputOf(uri))
+        new SyncFunc<>(
+            new SoftFunc<>(
+                (Func<URI, Input>) uri -> new SyncInput(
+                    new StickyInput(new InputOf(uri))
+                )
             )
         )
     );

--- a/src/main/java/com/zerocracy/farm/ruled/RdIndex.java
+++ b/src/main/java/com/zerocracy/farm/ruled/RdIndex.java
@@ -20,7 +20,8 @@ import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.net.URI;
 import org.cactoos.Input;
-import org.cactoos.func.SolidFunc;
+import org.cactoos.cache.SoftFunc;
+import org.cactoos.func.SyncFunc;
 import org.cactoos.func.UncheckedFunc;
 import org.cactoos.io.InputOf;
 import org.cactoos.io.InputWithFallback;
@@ -42,9 +43,11 @@ final class RdIndex {
      * Cache of documents.
      */
     private static final UncheckedFunc<URI, Input> CACHE = new UncheckedFunc<>(
-        new SolidFunc<>(
-            path -> new SyncInput(
-                new StickyInput(new InputOf(path))
+        new SyncFunc<>(
+            new SoftFunc<>(
+                path -> new SyncInput(
+                    new StickyInput(new InputOf(path))
+                )
             )
         )
     );

--- a/src/main/java/com/zerocracy/farm/ruled/RdRules.java
+++ b/src/main/java/com/zerocracy/farm/ruled/RdRules.java
@@ -27,7 +27,8 @@ import java.util.Collection;
 import org.apache.commons.lang3.StringUtils;
 import org.cactoos.Func;
 import org.cactoos.Input;
-import org.cactoos.func.SolidFunc;
+import org.cactoos.cache.SoftFunc;
+import org.cactoos.func.SyncFunc;
 import org.cactoos.func.UncheckedFunc;
 import org.cactoos.io.InputOf;
 import org.cactoos.io.StickyInput;
@@ -51,9 +52,11 @@ final class RdRules {
      * Cache of documents.
      */
     private static final UncheckedFunc<URI, Input> CACHE = new UncheckedFunc<>(
-        new SolidFunc<>(
-            (Func<URI, Input>) uri -> new SyncInput(
-                new StickyInput(new InputOf(uri))
+        new SyncFunc<>(
+            new SoftFunc<>(
+                (Func<URI, Input>) uri -> new SyncInput(
+                    new StickyInput(new InputOf(uri))
+                )
             )
         )
     );

--- a/src/main/java/com/zerocracy/tk/XeXsl.java
+++ b/src/main/java/com/zerocracy/tk/XeXsl.java
@@ -24,7 +24,8 @@ import com.zerocracy.Project;
 import java.io.IOException;
 import java.net.URI;
 import javax.xml.transform.stream.StreamSource;
-import org.cactoos.func.SolidFunc;
+import org.cactoos.cache.SoftFunc;
+import org.cactoos.func.SyncFunc;
 import org.cactoos.func.UncheckedFunc;
 import org.cactoos.io.InputOf;
 import org.cactoos.io.InputStreamOf;
@@ -51,8 +52,10 @@ public final class XeXsl implements XeSource {
      */
     private static final UncheckedFunc<URI, String> STYLESHEETS =
         new UncheckedFunc<>(
-            new SolidFunc<>(
-                uri -> new TextOf(new InputOf(uri)).asString()
+            new SyncFunc<>(
+                new SoftFunc<>(
+                    uri -> new TextOf(new InputOf(uri)).asString()
+                )
             )
         );
 


### PR DESCRIPTION
#360 - using soft references for caching `xml`, `xsd` and `xsl` documents instead of keeping them in memory forever.