### PR TITLE
#1414 Disable delete_stale_jobs for QA inspectors

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pmo/agenda/delete_stale_jobs.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pmo/agenda/delete_stale_jobs.groovy
@@ -6,6 +6,7 @@ import com.zerocracy.Project
 import com.zerocracy.farm.Assume
 import com.zerocracy.pm.ClaimIn
 import com.zerocracy.pm.in.Orders
+import com.zerocracy.pm.staff.Roles
 import com.zerocracy.pmo.Agenda
 import com.zerocracy.pmo.People
 import com.zerocracy.pmo.Projects
@@ -25,8 +26,22 @@ def exec(Project pmo, XML xml) {
       if (pid == 'PMO') {
         return
       }
+      if (
+        new Roles(
+            farm.find(String.format("@id='%s'", pid)).iterator().next()
+        ).bootstrap().hasRole('QA')
+      ) {
+        return
+        // @todo #1414:30min Cleanup of stale jobs is disabled for QA roles.
+        //  This is because QA jobs are not in Orders, but in Reviews. This
+        //  causes a bug where QA agenda is removed even though the jobs have
+        //  not completed review yet. For QA roles, get the list of jobs from
+        //  Reviews.findByInspector(). Let's also add a Bundles test case
+        //  where delete_stale_jobs should clean up jobs that are not in
+        //  Reviews and retains those that are still awaiting verdict.
+      }
       orders.addAll(
-        new Orders(farm.find("@id='${pid}'")[0]).bootstrap().jobs(login)
+          new Orders(farm.find("@id='${pid}'")[0]).bootstrap().jobs(login)
       )
     }
     boolean updated = false

--- a/src/main/groovy/com/zerocracy/stk/pmo/agenda/delete_stale_jobs.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pmo/agenda/delete_stale_jobs.groovy
@@ -28,7 +28,7 @@ def exec(Project pmo, XML xml) {
       }
       if (
         new Roles(
-            farm.find(String.format("@id='%s'", pid)).iterator().next()
+            farm.find("@id='${pid}'").iterator().next()
         ).bootstrap().hasRole('QA')
       ) {
         return
@@ -41,7 +41,7 @@ def exec(Project pmo, XML xml) {
         //  Reviews and retains those that are still awaiting verdict.
       }
       orders.addAll(
-          new Orders(farm.find("@id='${pid}'")[0]).bootstrap().jobs(login)
+        new Orders(farm.find("@id='${pid}'")[0]).bootstrap().jobs(login)
       )
     }
     boolean updated = false

--- a/src/main/java/com/zerocracy/pm/qa/Reviews.java
+++ b/src/main/java/com/zerocracy/pm/qa/Reviews.java
@@ -27,6 +27,7 @@ import com.zerocracy.cash.Cash;
 import com.zerocracy.pm.ClaimOut;
 import java.io.IOException;
 import java.util.Date;
+import java.util.List;
 import org.cactoos.iterable.ItemAt;
 import org.cactoos.iterable.Mapped;
 import org.cactoos.scalar.IoCheckedScalar;
@@ -41,7 +42,7 @@ import org.xembly.Directives;
  * @since 1.0
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 public final class Reviews {
 
     /**
@@ -271,6 +272,23 @@ public final class Reviews {
             return !new Xocument(reviews.path()).nodes(
                 String.format("//review[@job='%s']", job)
             ).isEmpty();
+        }
+    }
+
+    /**
+     * Find jobs to review by inspector.
+     * @param login Login name of inspector
+     * @return List of jobs to review
+     * @throws IOException If fails
+     */
+    public List<String> findByInspector(final String login)
+        throws IOException {
+        try (final Item reviews = this.item()) {
+            return new Xocument(reviews.path()).xpath(
+                String.format(
+                    "/reviews/review[inspector='%s']/@job", login
+                )
+            );
         }
     }
 

--- a/src/test/java/com/zerocracy/pm/qa/ReviewsTest.java
+++ b/src/test/java/com/zerocracy/pm/qa/ReviewsTest.java
@@ -83,4 +83,23 @@ public final class ReviewsTest {
         );
     }
 
+    @Test
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+    public void fetchesReviewsOfInspector() throws Exception {
+        final Reviews reviews = new Reviews(new FkProject()).bootstrap();
+        final String[] jobs =
+            {"gh:yegor256/0pdd#200", "gh:yegor256/0pdd#201"};
+        final String inspector = "ypshenychka";
+        for (final String job : jobs) {
+            reviews.add(
+                job, inspector, "carlosmiranda",
+                new Cash.S("$111"), 1, new Cash.S("$24")
+            );
+        }
+        MatcherAssert.assertThat(
+            reviews.findByInspector(inspector),
+            Matchers.contains(jobs)
+        );
+    }
+
 }


### PR DESCRIPTION
#1414: `delete_stale_jobs.groovy` does not work properly for QA inspection tasks. The reason is that `delete_stale_jobs` looks at `Orders`, but QA inspection jobs are actually in `Reviews`.

In order to avoid this bug:
1. Disabled it in case the person has `QA` role in the project. 
2. `Reviews.findByInspector()` added to find all QA jobs by inspector.
3. Added puzzle for proper implementation.