### PR TITLE
#1193 using table to display debts

### DIFF
--- a/src/main/resources/xsl/profile.xsl
+++ b/src/main/resources/xsl/profile.xsl
@@ -15,6 +15,12 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
+<!--
+@todo #1193:30min When https://github.com/zerocracy/datum/issues/375 is done we should refactor
+ this template to display debts table with Date | Project | Amount | Job. Where job
+ should be a job number with a link to the issue/PR, and amount should include both cash value and
+ minutes.
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.w3.org/1999/xhtml" version="2.0">
   <xsl:output method="html" doctype-system="about:legacy-compat" encoding="UTF-8" indent="yes"/>
   <xsl:strip-space elements="*"/>


### PR DESCRIPTION
#1193 
* using table to display current debts values
* added todo to refactor after changes in datum (https://github.com/zerocracy/datum/issues/375) are complete

Table will look like this:
![image](https://user-images.githubusercontent.com/105730/42996175-14297abe-8c13-11e8-9df4-6c8ae7dfac7e.png)
