### PR TITLE
For #733: Added todo for fixing the problem.

### DIFF
--- a/src/main/java/com/zerocracy/farm/StkSafe.java
+++ b/src/main/java/com/zerocracy/farm/StkSafe.java
@@ -73,6 +73,13 @@ public final class StkSafe implements Stakeholder {
         this.origin = stk;
     }
 
+    // @todo #733:30min Prevent StkSafe from swallowing exceptions generated
+    //  in tests. It was discovered in #733 that StkSafe is treating all
+    //  exceptions requests in the same way: thay're wrapped in an notify
+    //  claim and processed. This causes tests to never fail when throwing
+    //  exceptions: the exception which should break the test is treated like
+    //  a notification and does not breaks it. We should create a way to
+    //  avoid this exception swallowing.
     @Override
     @SuppressWarnings(
         {


### PR DESCRIPTION
For #733: I've discovered that the problem of exception swallowing in `BundlesTest` happens due to `StkSafe` treating exceptions generated in code as a `Notify` claim directed to the `test` channel, and then these exceptions are treated like any other notifications and don't break the test execution. I've added a `@todo` to the code explaining and narrowing the problem of #733 o `StkSafe`.