### PR TITLE
#1438 BundlesTest can now fetch resources from subdirectories

### DIFF
--- a/src/test/java/com/zerocracy/BundlesTest.java
+++ b/src/test/java/com/zerocracy/BundlesTest.java
@@ -215,7 +215,8 @@ public final class BundlesTest {
                                 new OutputTo(
                                     this.home.resolve(pfx).resolve(
                                         path.substring(
-                                            path.lastIndexOf('/') + 1
+                                            path.lastIndexOf(this.bundle)
+                                                + this.bundle.length() + 1
                                         ).replaceFirst("^pmo_", "")
                                     )
                                 )

--- a/src/test/resources/com/zerocracy/bundles/fetches_subdirectories/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/fetches_subdirectories/_after.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.graduation
+
+import com.jcabi.xml.XML
+import com.zerocracy.Project
+
+def exec(Project project, XML xml) {
+  // Nothing to do.
+}

--- a/src/test/resources/com/zerocracy/bundles/fetches_subdirectories/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/fetches_subdirectories/_after.groovy
@@ -14,7 +14,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.zerocracy.bundles.graduation
+package com.zerocracy.bundles.fetches_subdirectories
 
 import com.jcabi.xml.XML
 import com.zerocracy.Project

--- a/src/test/resources/com/zerocracy/bundles/fetches_subdirectories/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/fetches_subdirectories/_before.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.graduation
+
+import com.jcabi.xml.XML
+import com.zerocracy.Project
+import org.cactoos.text.TextOf
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+def exec(Project project, XML xml) {
+  project.acq('claims.xml').withCloseable {
+    MatcherAssert.assertThat(
+      new TextOf(it.iterator().next().path()).asString(),
+      Matchers.containsString('<claims xmlns:xsi=')
+    )
+  }
+  project.acq('options/foo.xml').withCloseable {
+    MatcherAssert.assertThat(
+      new TextOf(it.iterator().next().path()).asString(),
+      Matchers.containsString('<options xmlns:xsi=')
+    )
+  }
+}

--- a/src/test/resources/com/zerocracy/bundles/fetches_subdirectories/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/fetches_subdirectories/_before.groovy
@@ -14,7 +14,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.zerocracy.bundles.graduation
+package com.zerocracy.bundles.fetches_subdirectories
+
 
 import com.jcabi.xml.XML
 import com.zerocracy.Project

--- a/src/test/resources/com/zerocracy/bundles/fetches_subdirectories/_setup.xml
+++ b/src/test/resources/com/zerocracy/bundles/fetches_subdirectories/_setup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<setup>
+  <pmo>true</pmo>
+</setup>

--- a/src/test/resources/com/zerocracy/bundles/fetches_subdirectories/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/fetches_subdirectories/claims.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.2/xsd/pm/claims.xsd" version="0.1" updated="2017-03-27T11:18:09.228Z">
+</claims>

--- a/src/test/resources/com/zerocracy/bundles/fetches_subdirectories/options/foo.xml
+++ b/src/test/resources/com/zerocracy/bundles/fetches_subdirectories/options/foo.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<options xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.2/xsd/pm/staff/roles.xsd" version="0.1" updated="2017-08-18T13:18:00.000Z">
+</options>


### PR DESCRIPTION
#1438: Fixed bug where `BundlesTest` could not fetch resources from the bundle subdirectories.

The problem was that it tried to get the XML path relative to the bundle path. However, by checking `lastIndexOf('/')`, it ended up eating the subdirectory path as well:

* `com/zerocracy/bundles/fetches_subdirectories/options/foo.xml` -> `foo.xml`

This was fixed so that the relative path is now checked against not just `/` but the entire bundle path (e.g. `com/zerocracy/bundles/fetches_subdirectories/`

* `com/zerocracy/bundles/fetches_subdirectories/options/foo.xml` -> `options/foo.xml`
 
Also added a bundles test to see if it can get project file contents both from the bundle home directory and subdirectory.