### PR TITLE
#1116 fix resign on delay for unfunded projects

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pm/in/orders/resign_on_delay.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/in/orders/resign_on_delay.groovy
@@ -15,15 +15,15 @@ import com.zerocracy.pm.in.Orders
 import com.zerocracy.pm.scope.Wbs
 import com.zerocracy.pm.staff.Roles
 import com.zerocracy.pmo.Pmo
-import org.cactoos.iterable.Filtered
-import org.cactoos.iterable.Limited
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
+import org.cactoos.iterable.Filtered
+import org.cactoos.iterable.Limited
 
 def exec(Project project, XML xml) {
   new Assume(project, xml).notPmo()
   new Assume(project, xml).type('Ping')
-  if (new Ledger(project).bootstrap().deficit()) {
+  if (new Ledger(project).bootstrap().cash().decimal() <= BigDecimal.ZERO) {
     // We must not resign when the project is not funded, simply
     // because developers can't do anything without money. Their PRs
     // will have no reviewers, etc.

--- a/src/main/groovy/com/zerocracy/stk/pm/in/orders/resign_on_delay.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/in/orders/resign_on_delay.groovy
@@ -21,6 +21,14 @@ import java.time.ZonedDateTime
 import org.cactoos.iterable.Filtered
 import org.cactoos.iterable.Limited
 
+/**
+ * Resign an order that is kept for too long.
+ * Orders in unfunded projects are not resigned at all, similarly REV tasks
+ * are not resigned even in funded projects.
+ *
+ * @param project A project
+ * @param xml XML file received
+ */
 def exec(Project project, XML xml) {
   new Assume(project, xml).notPmo()
   new Assume(project, xml).type('Ping')

--- a/src/test/java/com/zerocracy/BundlesTest.java
+++ b/src/test/java/com/zerocracy/BundlesTest.java
@@ -150,7 +150,7 @@ public final class BundlesTest {
                 },
                 new Sorted<>(
                     new Reflections(
-                        "com.zerocracy.bundles.dont_resign_on_delay_unfunded_project", new ResourcesScanner()
+                        "com.zerocracy.bundles.resign_on_delay", new ResourcesScanner()
                     ).getResources(p -> p.endsWith("claims.xml"))
                 )
             )

--- a/src/test/java/com/zerocracy/BundlesTest.java
+++ b/src/test/java/com/zerocracy/BundlesTest.java
@@ -150,7 +150,7 @@ public final class BundlesTest {
                 },
                 new Sorted<>(
                     new Reflections(
-                        "com.zerocracy.bundles", new ResourcesScanner()
+                        "com.zerocracy.bundles.dont_resign_on_delay_unfunded_project", new ResourcesScanner()
                     ).getResources(p -> p.endsWith("claims.xml"))
                 )
             )

--- a/src/test/java/com/zerocracy/BundlesTest.java
+++ b/src/test/java/com/zerocracy/BundlesTest.java
@@ -150,7 +150,7 @@ public final class BundlesTest {
                 },
                 new Sorted<>(
                     new Reflections(
-                        "com.zerocracy.bundles.resign_on_delay", new ResourcesScanner()
+                        "com.zerocracy.bundles", new ResourcesScanner()
                     ).getResources(p -> p.endsWith("claims.xml"))
                 )
             )

--- a/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/_after.groovy
@@ -24,12 +24,12 @@ import org.hamcrest.Matchers
 
 def exec(Project project, XML xml) {
   MatcherAssert.assertThat(
-    'Issue was resigned',
+    'Issue should not have been resigned',
     new Orders(project).bootstrap().jobs('lazydev'),
     Matchers.contains('gh:test/test#1')
   )
   MatcherAssert.assertThat(
-    'PR was resigned',
+    'CR should not have been resigned',
     new Orders(project).bootstrap().jobs('lazyrev'),
     Matchers.contains('gh:test/test#2')
   )

--- a/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/_after.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.dont_resign_on_delay_unfunded_project
+
+import com.jcabi.xml.XML
+import com.zerocracy.Project
+import com.zerocracy.pm.in.Orders
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+def exec(Project project, XML xml) {
+  MatcherAssert.assertThat(
+    'Issue was resigned',
+    new Orders(project).bootstrap().jobs('lazydev'),
+    Matchers.contains('gh:test/test#1')
+  )
+  MatcherAssert.assertThat(
+    'PR was resigned',
+    new Orders(project).bootstrap().jobs('lazyrev'),
+    Matchers.contains('gh:test/test#2')
+  )
+}

--- a/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/_before.groovy
@@ -16,7 +16,7 @@
  */
 package com.zerocracy.bundles.dont_resign_on_delay_unfunded_project
 
-import com.jcabi.github.Github
+
 import com.jcabi.github.Repo
 import com.jcabi.github.Repos
 import com.jcabi.xml.XML
@@ -29,8 +29,7 @@ import org.hamcrest.Matchers
 
 def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
-  Github github = new ExtGithub(farm).value()
-  Repo repo = github.repos().create(new Repos.RepoCreate('test', false))
+  Repo repo = new ExtGithub(farm).value().repos().create(new Repos.RepoCreate('test', false))
   repo.issues().create('Issue title', 'Issue body')
   repo.pulls().create('PR title', 'master', 'master')
   MatcherAssert.assertThat(

--- a/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/_before.groovy
@@ -23,6 +23,9 @@ import com.jcabi.xml.XML
 import com.zerocracy.Farm
 import com.zerocracy.Project
 import com.zerocracy.entry.ExtGithub
+import com.zerocracy.pm.cost.Ledger
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
 
 def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
@@ -30,4 +33,8 @@ def exec(Project project, XML xml) {
   Repo repo = github.repos().create(new Repos.RepoCreate('test', false))
   repo.issues().create('Issue title', 'Issue body')
   repo.pulls().create('PR title', 'master', 'master')
+  MatcherAssert.assertThat(
+    new Ledger(project).bootstrap().cash().decimal(),
+    Matchers.comparesEqualTo(BigDecimal.ZERO)
+  )
 }

--- a/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/_before.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.dont_resign_on_delay_unfunded_project
+
+import com.jcabi.github.Github
+import com.jcabi.github.Repo
+import com.jcabi.github.Repos
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.entry.ExtGithub
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  Github github = new ExtGithub(farm).value()
+  Repo repo = github.repos().create(new Repos.RepoCreate('test', false))
+  repo.issues().create('Issue title', 'Issue body')
+  repo.pulls().create('PR title', 'master', 'master')
+}

--- a/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/claims.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.5/xsd/pm/claims.xsd" version="0.1" updated="2017-08-18T13:18:00.000Z">
+  <claim id="1">
+    <type>Ping</type>
+    <created>2018-01-20T11:18:09.228Z</created>
+  </claim>
+</claims>

--- a/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/claims.xml
@@ -18,6 +18,6 @@ SOFTWARE.
 <claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.5/xsd/pm/claims.xsd" version="0.1" updated="2017-08-18T13:18:00.000Z">
   <claim id="1">
     <type>Ping</type>
-    <created>2018-01-20T11:18:09.228Z</created>
+    <created>2018-07-23T11:18:09.228Z</created>
   </claim>
 </claims>

--- a/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/orders.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/orders.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<orders xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.5/xsd/pm/in/orders.xsd" version="0.1" updated="2017-08-18T13:18:00.000Z">
+  <order job="gh:test/test#1">
+    <created>2017-08-18T13:18:00.000Z</created>
+    <performer>lazydev</performer>
+    <reason>some reason</reason>
+  </order>
+  <order job="gh:test/test#2">
+    <created>2017-08-18T13:18:00.000Z</created>
+    <performer>lazyrev</performer>
+    <reason>some reason</reason>
+  </order>
+</orders>

--- a/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/orders.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/orders.xml
@@ -17,12 +17,12 @@ SOFTWARE.
 -->
 <orders xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.5/xsd/pm/in/orders.xsd" version="0.1" updated="2017-08-18T13:18:00.000Z">
   <order job="gh:test/test#1">
-    <created>2017-08-18T13:18:00.000Z</created>
+    <created>2018-07-18T13:18:00.000Z</created>
     <performer>lazydev</performer>
     <reason>some reason</reason>
   </order>
   <order job="gh:test/test#2">
-    <created>2017-08-18T13:18:00.000Z</created>
+    <created>2018-07-18T13:18:00.000Z</created>
     <performer>lazyrev</performer>
     <reason>some reason</reason>
   </order>

--- a/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/roles.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/roles.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<roles xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.5/xsd/pm/staff/roles.xsd" version="0.1" updated="2017-08-18T13:18:00.000Z">
+  <person id="lazydev">
+    <role>DEV</role>
+  </person>
+  <person id="lazyrev">
+    <role>REV</role>
+  </person>
+</roles>

--- a/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/wbs.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/wbs.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<wbs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.5/xsd/pm/scope/wbs.xsd" version="0.1" updated="2017-08-18T13:18:00.000Z">
+  <job id="gh:test/test#1">
+    <role>DEV</role>
+    <created>2018-01-01T13:18:00.000Z</created>
+  </job>
+  <job id="gh:test/test#2">
+    <role>REV</role>
+    <created>2018-01-01T13:18:00.000Z</created>
+  </job>
+</wbs>

--- a/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/wbs.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_resign_on_delay_unfunded_project/wbs.xml
@@ -18,10 +18,10 @@ SOFTWARE.
 <wbs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.5/xsd/pm/scope/wbs.xsd" version="0.1" updated="2017-08-18T13:18:00.000Z">
   <job id="gh:test/test#1">
     <role>DEV</role>
-    <created>2018-01-01T13:18:00.000Z</created>
+    <created>2018-04-01T13:18:00.000Z</created>
   </job>
   <job id="gh:test/test#2">
     <role>REV</role>
-    <created>2018-01-01T13:18:00.000Z</created>
+    <created>2018-04-01T13:18:00.000Z</created>
   </job>
 </wbs>

--- a/src/test/resources/com/zerocracy/bundles/resign_on_delay/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/resign_on_delay/_before.groovy
@@ -22,7 +22,9 @@ import com.jcabi.github.Repos
 import com.jcabi.xml.XML
 import com.zerocracy.Farm
 import com.zerocracy.Project
+import com.zerocracy.cash.Cash
 import com.zerocracy.entry.ExtGithub
+import com.zerocracy.pm.cost.Ledger
 
 def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
@@ -30,4 +32,12 @@ def exec(Project project, XML xml) {
   Repo repo = github.repos().create(new Repos.RepoCreate('test', false))
   repo.issues().create('Issue title', 'Issue body')
   repo.pulls().create('PR title', 'master', 'master')
+  new Ledger(project).bootstrap().add(
+    new Ledger.Transaction(
+      new Cash.S('$1000'),
+      'assets', 'cash',
+      'income', "@guy",
+      'Contributed via Stripe by someone'
+    )
+  )
 }

--- a/src/test/resources/com/zerocracy/bundles/resign_on_delay/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/resign_on_delay/_before.groovy
@@ -36,7 +36,7 @@ def exec(Project project, XML xml) {
     new Ledger.Transaction(
       new Cash.S('$1000'),
       'assets', 'cash',
-      'income', "@guy",
+      'income', '@guy',
       'Contributed via Stripe by someone'
     )
   )


### PR DESCRIPTION
#1116 
- added test for validating that neither DEV nor REV jobs are resigned for unfunded projects
- fixed problem in resign_on_delay.groovy