### PR TITLE
SQS claims

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@ SOFTWARE.
     <mongo.version>3.8.0</mongo.version>
     <telegram.version>3.6</telegram.version>
     <branch.coverage>0.45</branch.coverage>
+    <aws.version>1.11.211</aws.version>
   </properties>
   <repositories>
     <repository>
@@ -213,17 +214,22 @@ SOFTWARE.
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>1.11.211</version>
+      <version>${aws.version}</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.11.211</version>
+      <version>${aws.version}</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-dynamodb</artifactId>
-      <version>1.11.211</version>
+      <version>${aws.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sqs</artifactId>
+      <version>${aws.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/com/zerocracy/entry/ClaimsOf.java
+++ b/src/main/java/com/zerocracy/entry/ClaimsOf.java
@@ -54,7 +54,7 @@ public final class ClaimsOf implements Claims {
                     if (props.has("//sqs")) {
                         final AmazonSQS sqs = new ExtSqs(farm).value();
                         final String name =
-                            String.format("project-%s.fifo", project.pid());
+                            String.format("0crat-%s.fifo", project.pid());
                         String url;
                         try {
                             url = sqs.getQueueUrl(name).getQueueUrl();

--- a/src/main/java/com/zerocracy/entry/ClaimsOf.java
+++ b/src/main/java/com/zerocracy/entry/ClaimsOf.java
@@ -54,23 +54,23 @@ public final class ClaimsOf implements Claims {
                     if (props.has("//sqs")) {
                         final AmazonSQS sqs = new ExtSqs(farm).value();
                         final String name =
-                            String.format("project-%s", project.pid());
+                            String.format("project-%s.fifo", project.pid());
                         String url;
                         try {
                             url = sqs.getQueueUrl(name).getQueueUrl();
                         } catch (final QueueDoesNotExistException ignored) {
                             url = sqs.createQueue(
                                 new CreateQueueRequest(name)
-                                .withAttributes(
-                                    new MapOf<>(
-                                        // @checkstyle LineLength (2 lines)
-                                        new MapEntry<>("FifoQueue", "true"),
-                                        new MapEntry<>("ContentBasedDeduplication", "true")
+                                    .withAttributes(
+                                        new MapOf<String, String>(
+                                            // @checkstyle LineLength (2 lines)
+                                            new MapEntry<>("FifoQueue", Boolean.toString(true)),
+                                            new MapEntry<>("ContentBasedDeduplication", Boolean.toString(true))
+                                        )
                                     )
-                                )
                             ).getQueueUrl();
                         }
-                        claims = new ClaimsSqs(sqs, url);
+                        claims = new ClaimsSqs(sqs, url, project);
                     } else {
                         claims = new ClaimsXml(project);
                     }

--- a/src/main/java/com/zerocracy/entry/ExtSqs.java
+++ b/src/main/java/com/zerocracy/entry/ExtSqs.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.entry;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClient;
+import com.zerocracy.Farm;
+import com.zerocracy.farm.props.Props;
+import org.cactoos.Scalar;
+import org.cactoos.func.IoCheckedFunc;
+import org.cactoos.func.SolidFunc;
+
+/**
+ * SQS client.
+ *
+ * @since 1.0
+ */
+public final class ExtSqs implements Scalar<AmazonSQS> {
+
+    /**
+     * Instances.
+     */
+    private static final IoCheckedFunc<Farm, AmazonSQS> INSTANCES =
+        new IoCheckedFunc<>(
+            new SolidFunc<>(
+                frm -> {
+                    final Props props = new Props(frm);
+                    return AmazonSQSClient.builder()
+                        .withCredentials(
+                            new AWSStaticCredentialsProvider(
+                                new BasicAWSCredentials(
+                                    props.get("//sqs/key"),
+                                    props.get("//sqs/secret")
+                                )
+                            )
+                        ).withRegion(Regions.US_EAST_1)
+                        .build();
+                }
+            )
+        );
+
+    /**
+     * Farm.
+     */
+    private final Farm farm;
+
+    /**
+     * Ctor.
+     *
+     * @param farm Farm
+     */
+    public ExtSqs(final Farm farm) {
+        this.farm = farm;
+    }
+
+    @Override
+    public AmazonSQS value() throws Exception {
+        return ExtSqs.INSTANCES.apply(this.farm);
+    }
+}

--- a/src/main/java/com/zerocracy/entry/ExtSqs.java
+++ b/src/main/java/com/zerocracy/entry/ExtSqs.java
@@ -17,12 +17,10 @@
 package com.zerocracy.entry;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClient;
 import com.zerocracy.Farm;
-import com.zerocracy.farm.props.Props;
 import org.cactoos.Scalar;
 import org.cactoos.func.IoCheckedFunc;
 import org.cactoos.func.SolidFunc;
@@ -40,19 +38,13 @@ public final class ExtSqs implements Scalar<AmazonSQS> {
     private static final IoCheckedFunc<Farm, AmazonSQS> INSTANCES =
         new IoCheckedFunc<>(
             new SolidFunc<>(
-                frm -> {
-                    final Props props = new Props(frm);
-                    return AmazonSQSClient.builder()
-                        .withCredentials(
-                            new AWSStaticCredentialsProvider(
-                                new BasicAWSCredentials(
-                                    props.get("//sqs/key"),
-                                    props.get("//sqs/secret")
-                                )
-                            )
-                        ).withRegion(Regions.US_EAST_1)
-                        .build();
-                }
+                frm -> AmazonSQSClient.builder()
+                    .withCredentials(
+                        new AWSStaticCredentialsProvider(
+                            new PropsAwsCredentials(frm, "sqs")
+                        )
+                    ).withRegion(Regions.US_EAST_1)
+                    .build()
             )
         );
 

--- a/src/main/java/com/zerocracy/entry/PropsAwsCredentials.java
+++ b/src/main/java/com/zerocracy/entry/PropsAwsCredentials.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.entry;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.zerocracy.Farm;
+import com.zerocracy.farm.props.Props;
+import java.io.IOException;
+
+/**
+ * Credentials from {@code _props.xml}.
+ *
+ * @since 1.0
+ */
+public final class PropsAwsCredentials implements AWSCredentials {
+
+    /**
+     * Props.
+     */
+    private final Props props;
+
+    /**
+     * Xpath.
+     */
+    private final String name;
+
+    /**
+     * Ctor.
+     *
+     * @param farm Farm
+     * @param name Credentials name
+     */
+    public PropsAwsCredentials(final Farm farm, final String name) {
+        this(new Props(farm), name);
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param props Properties
+     * @param name Credentials name
+     */
+    public PropsAwsCredentials(final Props props, final String name) {
+        this.props = props;
+        this.name = name;
+    }
+
+    @Override
+    public String getAWSAccessKeyId() {
+        try {
+            return this.props.get(String.format("//%s/key", this.name));
+        } catch (final IOException err) {
+            throw new IllegalStateException("Failed to read key", err);
+        }
+    }
+
+    @Override
+    public String getAWSSecretKey() {
+        try {
+            return this.props.get(String.format("//%s/secret", this.name));
+        } catch (final IOException err) {
+            throw new IllegalStateException("Failed to read secret", err);
+        }
+    }
+}

--- a/src/main/java/com/zerocracy/entry/ValidClaims.java
+++ b/src/main/java/com/zerocracy/entry/ValidClaims.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.entry;
+
+import com.jcabi.xml.XML;
+import com.zerocracy.pm.Claims;
+import java.io.IOException;
+import org.cactoos.Proc;
+
+/**
+ * Validation decorator for claims.
+ * <p>
+ * It will not accept too big claims and prevent from
+ * take too many claims at once, see
+ * <a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-limits.html">
+ *     AWS SQS restrictions
+ * </a>
+ *
+ * @since 1.0
+ * @checkstyle MagicNumberCheck (500 lines)
+ */
+public final class ValidClaims implements Claims {
+
+    /**
+     * Can't take more than 10 claims.
+     */
+    private static final int MAX_LIMIT = 10;
+
+    /**
+     * Can't try to take less than 1 claim.
+     */
+    private static final int MIN_LIMIT = 1;
+
+    /**
+     * Max claim size is 256 KB.
+     */
+    private static final int MAX_CLAIM_LENGTH = 256 << 10;
+
+    /**
+     * Origin.
+     */
+    private final Claims claims;
+
+    /**
+     * Ctor.
+     *
+     * @param claims Origin claims
+     */
+    public ValidClaims(final Claims claims) {
+        this.claims = claims;
+    }
+
+    @Override
+    public void take(final Proc<XML> proc, final int limit)
+        throws IOException {
+        if (limit < ValidClaims.MIN_LIMIT || limit > ValidClaims.MAX_LIMIT) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Invalid limit value: %d, should be > 0 and <= 10",
+                    limit
+                )
+            );
+        }
+        this.claims.take(proc, limit);
+    }
+
+    @Override
+    public void submit(final XML claim) throws IOException {
+        if (claim.toString().length() > ValidClaims.MAX_CLAIM_LENGTH) {
+            throw new IllegalArgumentException(
+                "Claim is too big, max claim size is 256 KB"
+            );
+        }
+        this.claims.submit(claim);
+    }
+}

--- a/src/main/java/com/zerocracy/entry/ValidClaims.java
+++ b/src/main/java/com/zerocracy/entry/ValidClaims.java
@@ -70,8 +70,10 @@ public final class ValidClaims implements Claims {
         if (limit < ValidClaims.MIN_LIMIT || limit > ValidClaims.MAX_LIMIT) {
             throw new IllegalArgumentException(
                 String.format(
-                    "Invalid limit value: %d, should be > 0 and <= 10",
-                    limit
+                    "Invalid limit value: %d, should be >= %d and <= %d",
+                    limit,
+                    ValidClaims.MIN_LIMIT,
+                    ValidClaims.MAX_CLAIM_LENGTH
                 )
             );
         }
@@ -80,9 +82,14 @@ public final class ValidClaims implements Claims {
 
     @Override
     public void submit(final XML claim) throws IOException {
-        if (claim.toString().length() > ValidClaims.MAX_CLAIM_LENGTH) {
+        final int size = claim.toString().length();
+        if (size > ValidClaims.MAX_CLAIM_LENGTH) {
             throw new IllegalArgumentException(
-                "Claim is too big, max claim size is 256 KB"
+                String.format(
+                    "Claim is too big: %d bytes, max claim size is %d bytes",
+                    size,
+                    ValidClaims.MAX_CLAIM_LENGTH
+                )
             );
         }
         this.claims.submit(claim);

--- a/src/main/java/com/zerocracy/pm/ClaimOut.java
+++ b/src/main/java/com/zerocracy/pm/ClaimOut.java
@@ -56,7 +56,7 @@ public final class ClaimOut implements Iterable<Directive> {
     /**
      * Max delay for claim.
      */
-    private static final long MAX_DELAY_MINUTES = 15L;
+    private static final Duration MAX_DELAY = Duration.ofMinutes(15L);
 
     /**
      * Counter of IDs.
@@ -208,8 +208,7 @@ public final class ClaimOut implements Iterable<Directive> {
             Instant.now(),
             Instant.ofEpochSecond(seconds)
         );
-        if (delay
-            .compareTo(Duration.ofMinutes(ClaimOut.MAX_DELAY_MINUTES)) > 0) {
+        if (delay.compareTo(ClaimOut.MAX_DELAY) > 0) {
             throw new IOException("Can't set delay more than 15 minutes");
         }
         return new ClaimOut(

--- a/src/main/java/com/zerocracy/pm/ClaimOut.java
+++ b/src/main/java/com/zerocracy/pm/ClaimOut.java
@@ -209,7 +209,12 @@ public final class ClaimOut implements Iterable<Directive> {
             Instant.ofEpochSecond(seconds)
         );
         if (delay.compareTo(ClaimOut.MAX_DELAY) > 0) {
-            throw new IOException("Can't set delay more than 15 minutes");
+            throw new IOException(
+                String.format(
+                    "Can't set delay more than %s minutes",
+                    ClaimOut.MAX_DELAY.toMinutes()
+                )
+            );
         }
         return new ClaimOut(
             this.dirs

--- a/src/main/java/com/zerocracy/pm/ClaimOut.java
+++ b/src/main/java/com/zerocracy/pm/ClaimOut.java
@@ -21,6 +21,8 @@ import com.jcabi.xml.XMLDocument;
 import com.jcabi.xml.XSLChain;
 import com.jcabi.xml.XSLDocument;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Iterator;
@@ -50,6 +52,11 @@ import org.xembly.Xembler;
  */
 @SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 public final class ClaimOut implements Iterable<Directive> {
+
+    /**
+     * Max delay for claim.
+     */
+    private static final long MAX_DELAY_MINUTES = 15L;
 
     /**
      * Counter of IDs.
@@ -194,8 +201,17 @@ public final class ClaimOut implements Iterable<Directive> {
      * Until this amount of seconds.
      * @param seconds The amount of seconds to wait
      * @return This
+     * @throws IOException If fails
      */
-    public ClaimOut until(final long seconds) {
+    public ClaimOut until(final long seconds) throws IOException {
+        final Duration delay = Duration.between(
+            Instant.now(),
+            Instant.ofEpochSecond(seconds)
+        );
+        if (delay
+            .compareTo(Duration.ofMinutes(ClaimOut.MAX_DELAY_MINUTES)) > 0) {
+            throw new IOException("Can't set delay more than 15 minutes");
+        }
         return new ClaimOut(
             this.dirs
                 .push()

--- a/src/main/java/com/zerocracy/pm/ClaimsSqs.java
+++ b/src/main/java/com/zerocracy/pm/ClaimsSqs.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.pm;
+
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import org.cactoos.Proc;
+import org.cactoos.iterable.ItemAt;
+import org.cactoos.iterable.Mapped;
+import org.cactoos.map.MapOf;
+import org.cactoos.scalar.And;
+import org.cactoos.scalar.IoCheckedScalar;
+
+/**
+ * Claims queue on Amazon SQS.
+ *
+ * @since 1.0
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+public final class ClaimsSqs implements Claims {
+
+    /**
+     * SQS client.
+     */
+    private final AmazonSQS sqs;
+
+    /**
+     * Queue url.
+     */
+    private final String queue;
+
+    /**
+     * Ctor.
+     *
+     * @param sqs SQS client
+     * @param queue Queue url
+     */
+    public ClaimsSqs(final AmazonSQS sqs, final String queue) {
+        this.sqs = sqs;
+        this.queue = queue;
+    }
+
+    @Override
+    public void take(final Proc<XML> proc, final int limit)
+        throws IOException {
+        new IoCheckedScalar<>(
+            new And(
+                entry -> {
+                    proc.exec(entry.getValue().nodes("/claim").get(0));
+                    this.sqs.deleteMessage(
+                        this.queue, entry.getKey().getReceiptHandle()
+                    );
+                },
+                new MapOf<>(
+                    msg -> msg,
+                    msg -> new XMLDocument(msg.getBody()),
+                    this.sqs.receiveMessage(
+                        new ReceiveMessageRequest(this.queue)
+                            .withMaxNumberOfMessages(limit)
+                    ).getMessages()
+                ).entrySet()
+            )
+        ).value();
+    }
+
+    @Override
+    public void submit(final XML claim) throws IOException {
+        final SendMessageRequest msg = new SendMessageRequest(
+            this.queue,
+            claim.toString()
+        );
+        final long until = new IoCheckedScalar<>(
+            new ItemAt<>(
+                0L,
+                new Mapped<>(
+                    Long::parseLong,
+                    claim.xpath("/claim/until/text()")
+                )
+            )
+        ).value();
+        final long delay = Duration.between(
+            Instant.now(),
+            Instant.ofEpochSecond(until)
+        ).getSeconds();
+        if (delay > 0L) {
+            msg.setDelaySeconds((int) delay);
+        }
+        this.sqs.sendMessage(msg);
+    }
+}

--- a/src/main/java/com/zerocracy/pm/ClaimsSqs.java
+++ b/src/main/java/com/zerocracy/pm/ClaimsSqs.java
@@ -21,6 +21,7 @@ import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
+import com.zerocracy.Project;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -50,14 +51,22 @@ public final class ClaimsSqs implements Claims {
     private final String queue;
 
     /**
+     * Project.
+     */
+    private final Project project;
+
+    /**
      * Ctor.
      *
      * @param sqs SQS client
      * @param queue Queue url
+     * @param project Project
      */
-    public ClaimsSqs(final AmazonSQS sqs, final String queue) {
+    public ClaimsSqs(final AmazonSQS sqs, final String queue,
+        final Project project) {
         this.sqs = sqs;
         this.queue = queue;
+        this.project = project;
     }
 
     @Override
@@ -88,7 +97,7 @@ public final class ClaimsSqs implements Claims {
         final SendMessageRequest msg = new SendMessageRequest(
             this.queue,
             claim.toString()
-        );
+        ).withMessageGroupId(this.project.pid());
         final long until = new IoCheckedScalar<>(
             new ItemAt<>(
                 0L,

--- a/src/main/resources/com/zerocracy/_props.xml
+++ b/src/main/resources/com/zerocracy/_props.xml
@@ -65,6 +65,10 @@ SOFTWARE.
     <secret>${s3.secret}</secret>
     <bucket>${s3.bucket}</bucket>
   </s3>
+  <sqs>
+    <key>${sqs.key}</key>
+    <secret>${sqs.secret}</secret>
+  </sqs>
   <mongo>
     <dbname>${mongo.dbname}</dbname>
     <host>${mongo.host}</host>

--- a/src/test/java/com/zerocracy/entry/ClaimsOfITCase.java
+++ b/src/test/java/com/zerocracy/entry/ClaimsOfITCase.java
@@ -69,7 +69,7 @@ public final class ClaimsOfITCase {
         );
         final AmazonSQS sqs = new ExtSqs(farm).value();
         final String url = sqs.getQueueUrl(
-            String.format("project-%s.fifo", project.pid())
+            String.format("0crat-%s.fifo", project.pid())
         ).getQueueUrl();
         sqs.deleteQueue(url);
         MatcherAssert.assertThat(

--- a/src/test/java/com/zerocracy/entry/ClaimsOfITCase.java
+++ b/src/test/java/com/zerocracy/entry/ClaimsOfITCase.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.entry;
+
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.zerocracy.Farm;
+import com.zerocracy.Item;
+import com.zerocracy.Project;
+import com.zerocracy.farm.fake.FkFarm;
+import com.zerocracy.farm.fake.FkProject;
+import org.cactoos.io.LengthOf;
+import org.cactoos.io.TeeInput;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link ClaimsOf}.
+ * <p>
+ * To start this test you have to create AWS user with full access to
+ * SQS queues policy and insert credentials to SQS_KEY and SQS_SECRET
+ * fields.
+ *
+ * @since 1.0
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+@Ignore
+public final class ClaimsOfITCase {
+
+    /**
+     * SQS AWS key.
+     */
+    private static final String SQS_KEY = "";
+
+    /**
+     * SQS AWS secret.
+     */
+    private static final String SQS_SECRET = "";
+
+    @Test
+    public void createsNewQueue() throws Exception {
+        final Project project = new FkProject();
+        try (final Item item = project.acq("_props.xml")) {
+            new LengthOf(
+                new TeeInput(
+                    new Xembler(
+                        new Directives()
+                            .add("props")
+                            .add("sqs")
+                            .add("key").set(ClaimsOfITCase.SQS_KEY).up()
+                            .add("secret").set(ClaimsOfITCase.SQS_SECRET).up()
+                    ).xmlQuietly(),
+                    item.path()
+                )
+            ).value();
+        }
+        final Farm farm = new FkFarm(project);
+        new ClaimsOf(farm).take(
+            xml -> {
+            },
+            1
+        );
+        final AmazonSQS sqs = new ExtSqs(farm).value();
+        final String url = sqs.getQueueUrl(
+            String.format("project-%s", project.pid())
+        ).getQueueUrl();
+        sqs.deleteQueue(url);
+        MatcherAssert.assertThat(
+            url,
+            Matchers.not(Matchers.isEmptyOrNullString())
+        );
+    }
+}

--- a/src/test/java/com/zerocracy/entry/PingTest.java
+++ b/src/test/java/com/zerocracy/entry/PingTest.java
@@ -18,10 +18,12 @@ package com.zerocracy.entry;
 
 import com.jcabi.aspects.Tv;
 import com.jcabi.xml.XML;
+import com.zerocracy.Farm;
 import com.zerocracy.Item;
 import com.zerocracy.Xocument;
 import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.fake.FkProject;
+import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pm.ClaimIn;
 import com.zerocracy.pm.ClaimsItem;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -52,7 +54,7 @@ public final class PingTest {
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public void worksForSingleProject() throws Exception {
         final FkProject pkt = new FkProject();
-        final FkFarm farm = new FkFarm(pkt);
+        final Farm farm = new PropsFarm(new FkFarm(pkt));
         try (final Item item = pkt.acq("catalog.xml")) {
             new Xocument(item.path()).bootstrap("pmo/catalog");
             new Xocument(item.path()).modify(

--- a/src/test/java/com/zerocracy/farm/StkSafeTest.java
+++ b/src/test/java/com/zerocracy/farm/StkSafeTest.java
@@ -22,7 +22,6 @@ import com.zerocracy.Project;
 import com.zerocracy.SoftException;
 import com.zerocracy.Stakeholder;
 import com.zerocracy.entry.ClaimsOf;
-import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.fake.FkProject;
 import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pm.ClaimOut;
@@ -48,7 +47,7 @@ public final class StkSafeTest {
         final Stakeholder stk = Mockito.mock(Stakeholder.class);
         final Project project = new FkProject();
         new ClaimOut().type("hello you")
-            .postTo(new ClaimsOf(new FkFarm(), project));
+            .postTo(new ClaimsOf(new PropsFarm(), project));
         final XML claim = new ClaimsItem(project).iterate().iterator().next();
         Mockito.doThrow(new SoftException("")).when(stk).process(
             project, claim
@@ -62,7 +61,7 @@ public final class StkSafeTest {
         new ClaimOut()
             .type("Notify GitHub")
             .token("github;test/test#1")
-            .postTo(new ClaimsOf(new FkFarm(), project));
+            .postTo(new ClaimsOf(new PropsFarm(), project));
         final XML claim = new ClaimsItem(project).iterate().iterator().next();
         new StkSafe(
             "hello1",
@@ -79,7 +78,7 @@ public final class StkSafeTest {
     public void dontRepeatErrorClaims() throws Exception {
         final FkProject project = new FkProject();
         new ClaimOut().type("Error").postTo(
-            new ClaimsOf(new FkFarm(), project)
+            new ClaimsOf(new PropsFarm(), project)
         );
         final int before = new LengthOf(new ClaimsItem(project).iterate())
             .intValue();

--- a/src/test/java/com/zerocracy/farm/reactive/AsyncFlushTest.java
+++ b/src/test/java/com/zerocracy/farm/reactive/AsyncFlushTest.java
@@ -25,6 +25,7 @@ import com.zerocracy.Project;
 import com.zerocracy.Stakeholder;
 import com.zerocracy.entry.ClaimsOf;
 import com.zerocracy.farm.S3Farm;
+import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.farm.sync.SyncFarm;
 import com.zerocracy.pm.ClaimIn;
 import com.zerocracy.pm.ClaimOut;
@@ -51,7 +52,9 @@ public final class AsyncFlushTest {
             Files.createTempDirectory("").toFile(),
             "the-bucket"
         );
-        try (final Farm farm = new SyncFarm(new S3Farm(bucket))) {
+        try (
+            final Farm farm = new SyncFarm(new PropsFarm(new S3Farm(bucket)))
+        ) {
             final Project project = farm.find("@id='ABCZZFE03'")
                 .iterator().next();
             final AtomicInteger done = new AtomicInteger(0);

--- a/src/test/java/com/zerocracy/farm/reactive/BrigadeTest.java
+++ b/src/test/java/com/zerocracy/farm/reactive/BrigadeTest.java
@@ -18,13 +18,14 @@ package com.zerocracy.farm.reactive;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
+import com.zerocracy.Farm;
 import com.zerocracy.Project;
 import com.zerocracy.Stakeholder;
 import com.zerocracy.entry.ClaimsOf;
 import com.zerocracy.farm.MismatchException;
-import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.fake.FkProject;
 import com.zerocracy.farm.fake.FkStakeholder;
+import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pm.ClaimOut;
 import com.zerocracy.pm.ClaimsItem;
 import java.nio.file.Files;
@@ -73,14 +74,15 @@ public final class BrigadeTest {
             )
         ).intValue();
         final Project project = new FkProject();
+        final Farm farm = new PropsFarm();
         new ClaimOut().type("just some fun")
-            .postTo(new ClaimsOf(new FkFarm(), project));
+            .postTo(new ClaimsOf(farm, project));
         final ClaimsItem claims = new ClaimsItem(project).bootstrap();
         final XML xml = claims.iterate().iterator().next();
         final Brigade brigade = new Brigade(
             new StkGroovy(
                 new InputOf(file), "brigadetest-parsesgroovy",
-                new FkFarm()
+                farm
             )
         );
         brigade.apply(project, xml);
@@ -94,14 +96,14 @@ public final class BrigadeTest {
     public void runsGroovyScript() throws Exception {
         final Project project = new FkProject();
         new ClaimOut().type("Hello").token("test;notoken").postTo(
-            new ClaimsOf(new FkFarm(), project)
+            new ClaimsOf(new PropsFarm(), project)
         );
         final ClaimsItem claims = new ClaimsItem(project).bootstrap();
         final XML xml = claims.iterate().iterator().next();
         final Brigade brigade = new Brigade(
             new StkRuntime(
                 com.zerocracy.stk.hello.class,
-                new FkFarm()
+                new PropsFarm()
             )
         );
         brigade.apply(project, xml);

--- a/src/test/java/com/zerocracy/farm/reactive/DefaultFlushTest.java
+++ b/src/test/java/com/zerocracy/farm/reactive/DefaultFlushTest.java
@@ -16,8 +16,9 @@
  */
 package com.zerocracy.farm.reactive;
 
+import com.zerocracy.Farm;
 import com.zerocracy.Project;
-import com.zerocracy.farm.fake.FkFarm;
+import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pm.ClaimsItem;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -34,7 +35,7 @@ public final class DefaultFlushTest {
 
     @Test
     public void processesAllClaims() throws Exception {
-        final FkFarm farm = new FkFarm();
+        final Farm farm = new PropsFarm();
         final Project project = farm.find("@id='DFLTFLUSHT'")
             .iterator().next();
         try (final Flush flush = new DefaultFlush(farm, new Brigade())) {

--- a/src/test/java/com/zerocracy/farm/reactive/RvProjectTest.java
+++ b/src/test/java/com/zerocracy/farm/reactive/RvProjectTest.java
@@ -21,7 +21,7 @@ import com.zerocracy.Farm;
 import com.zerocracy.Project;
 import com.zerocracy.RunsInThreads;
 import com.zerocracy.entry.ClaimsOf;
-import com.zerocracy.farm.fake.FkFarm;
+import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.farm.sync.SyncFarm;
 import com.zerocracy.pm.ClaimOut;
 import com.zerocracy.pm.ClaimsItem;
@@ -43,7 +43,7 @@ public final class RvProjectTest {
     @Test
     public void closesClaims() throws Exception {
         final AtomicInteger done = new AtomicInteger();
-        try (final Farm farm = new SyncFarm(new FkFarm())) {
+        try (final Farm farm = new SyncFarm(new PropsFarm())) {
             final Project raw = new Pmo(farm);
             final Flush def = new DefaultFlush(
                 farm, new Brigade(
@@ -70,7 +70,7 @@ public final class RvProjectTest {
     @Test
     public void closesClaimsInThreads() throws Exception {
         final AtomicInteger total = new AtomicInteger(Tv.FIFTY);
-        try (final Farm farm = new SyncFarm(new FkFarm())) {
+        try (final Farm farm = new SyncFarm(new PropsFarm())) {
             final Project raw = new Pmo(farm);
             final Flush def = new DefaultFlush(
                 farm, new Brigade(

--- a/src/test/java/com/zerocracy/farm/ruled/RdFarmTest.java
+++ b/src/test/java/com/zerocracy/farm/ruled/RdFarmTest.java
@@ -23,6 +23,7 @@ import com.zerocracy.Project;
 import com.zerocracy.RunsInThreads;
 import com.zerocracy.entry.ClaimsOf;
 import com.zerocracy.farm.S3Farm;
+import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.farm.strict.StrictFarm;
 import com.zerocracy.farm.sync.SyncFarm;
 import com.zerocracy.pm.ClaimOut;
@@ -77,7 +78,10 @@ public final class RdFarmTest {
             Files.createTempDirectory("").toFile(),
             "some-bucket-pmo"
         );
-        try (final Farm farm = new RdFarm(new StrictFarm(new S3Farm(bucket)))) {
+        try (
+            final Farm farm =
+                new RdFarm(new StrictFarm(new PropsFarm(new S3Farm(bucket))))
+        ) {
             final Project pmo = new Pmo(farm);
             new ClaimOut().type("hello you").postTo(new ClaimsOf(farm));
             MatcherAssert.assertThat(

--- a/src/test/java/com/zerocracy/pm/ClaimOutTest.java
+++ b/src/test/java/com/zerocracy/pm/ClaimOutTest.java
@@ -19,8 +19,8 @@ package com.zerocracy.pm;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.zerocracy.Project;
 import com.zerocracy.entry.ClaimsOf;
-import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.fake.FkProject;
+import com.zerocracy.farm.props.PropsFarm;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -65,7 +65,7 @@ public final class ClaimOutTest {
             .param("minutes", "45min")
             .param("cause_type", "Ping")
             .param("message", "hello, world")
-            .postTo(new ClaimsOf(new FkFarm(), project));
+            .postTo(new ClaimsOf(new PropsFarm(), project));
         MatcherAssert.assertThat(
             XhtmlMatchers.xhtml(
                 new ClaimsItem(project).iterate().iterator().next()
@@ -100,7 +100,7 @@ public final class ClaimOutTest {
                 .param("role", "this is not a role"),
         };
         final Project project = new FkProject();
-        final Claims claims = new ClaimsOf(new FkFarm(), project);
+        final Claims claims = new ClaimsOf(new PropsFarm(), project);
         for (final ClaimOut claim : data) {
             try {
                 claim.postTo(claims);

--- a/src/test/java/com/zerocracy/pm/ClaimsSqsITCase.java
+++ b/src/test/java/com/zerocracy/pm/ClaimsSqsITCase.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.pm;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClient;
+import com.jcabi.aspects.Tv;
+import com.jcabi.log.Logger;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Test case for {@link ClaimsSqs}.
+ * <p>
+ * See {@link com.zerocracy.entry.ClaimsOfITCase} for usage.
+ *
+ * @since 1.0
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+@Ignore
+public final class ClaimsSqsITCase {
+
+    /**
+     * SQS AWS key.
+     */
+    private static final String SQS_KEY = "";
+
+    /**
+     * SQS AWS secret.
+     */
+    private static final String SQS_SECRET = "";
+
+    /**
+     * SQS client.
+     */
+    private AmazonSQS client;
+    /**
+     * Queue url.
+     */
+    private String queue;
+
+    @Before
+    public void setUp() {
+        this.client = AmazonSQSClient.builder()
+            .withCredentials(
+                new AWSStaticCredentialsProvider(
+                    new BasicAWSCredentials(
+                        ClaimsSqsITCase.SQS_KEY,
+                        ClaimsSqsITCase.SQS_SECRET
+                    )
+                )
+            ).withRegion(Regions.DEFAULT_REGION)
+            .build();
+        this.queue = this.client
+            .createQueue(UUID.randomUUID().toString()).getQueueUrl();
+        Logger.info(this, "Created queue: %s", this.queue);
+    }
+
+    @After
+    public void tearDown() {
+        this.client.deleteQueue(this.queue);
+        Logger.info(this, "Queue destroyed: %s", this.queue);
+    }
+
+    @Test
+    public void sendAndReceiveClaim() throws Exception {
+        final Claims claims = new ClaimsSqs(this.client, this.queue);
+        final String type = "test";
+        new ClaimOut()
+            .type(type)
+            .postTo(claims);
+        final List<ClaimIn> received = new CopyOnWriteArrayList<>();
+        claims.take(xml -> received.add(new ClaimIn(xml)), Tv.TEN);
+        MatcherAssert.assertThat(
+            received,
+            Matchers.hasSize(1)
+        );
+        final ClaimIn claim = received.get(0);
+        MatcherAssert.assertThat(
+            claim.type(),
+            Matchers.equalTo(type)
+        );
+    }
+}

--- a/src/test/java/com/zerocracy/radars/ClaimOnQuestionTest.java
+++ b/src/test/java/com/zerocracy/radars/ClaimOnQuestionTest.java
@@ -18,8 +18,8 @@ package com.zerocracy.radars;
 
 import com.jcabi.xml.XMLDocument;
 import com.zerocracy.entry.ClaimsOf;
-import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.fake.FkProject;
+import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pm.ClaimsItem;
 import java.util.Collection;
 import org.cactoos.list.SolidList;
@@ -62,7 +62,7 @@ public final class ClaimOnQuestionTest {
         );
         final FkProject project = new FkProject();
         new ClaimOnQuestion(question).claim()
-            .postTo(new ClaimsOf(new FkFarm(), project));
+            .postTo(new ClaimsOf(new PropsFarm(), project));
         final ClaimsItem claims = new ClaimsItem(project).bootstrap();
         MatcherAssert.assertThat(
             claims.iterate(),

--- a/src/test/java/com/zerocracy/radars/github/RbAddToMilestoneTest.java
+++ b/src/test/java/com/zerocracy/radars/github/RbAddToMilestoneTest.java
@@ -22,7 +22,8 @@ import com.jcabi.github.Repo;
 import com.jcabi.github.Repos;
 import com.jcabi.github.mock.MkGithub;
 import com.jcabi.xml.XML;
-import com.zerocracy.farm.fake.FkFarm;
+import com.zerocracy.Farm;
+import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pm.ClaimIn;
 import com.zerocracy.pm.ClaimsItem;
 import java.io.IOException;
@@ -51,7 +52,7 @@ public final class RbAddToMilestoneTest {
         final Milestone milestone =
             repo.milestones().create("my milestone");
         new Issue.Smart(bug).milestone(milestone);
-        final FkFarm farm = new FkFarm();
+        final Farm farm = new PropsFarm();
         MatcherAssert.assertThat(
             new RbAddToMilestone().react(
                 farm,

--- a/src/test/java/com/zerocracy/radars/github/RbMilestoneTest.java
+++ b/src/test/java/com/zerocracy/radars/github/RbMilestoneTest.java
@@ -19,7 +19,7 @@ package com.zerocracy.radars.github;
 import com.jcabi.github.Repo;
 import com.jcabi.github.Repos;
 import com.jcabi.github.mock.MkGithub;
-import com.zerocracy.farm.fake.FkFarm;
+import com.zerocracy.farm.props.PropsFarm;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -39,7 +39,7 @@ public final class RbMilestoneTest {
         final int number = 1;
         MatcherAssert.assertThat(
             new RbMilestone().react(
-                new FkFarm(),
+                new PropsFarm(),
                 github,
                 Json.createObjectBuilder()
                     .add(

--- a/src/test/java/com/zerocracy/radars/github/RbOnBugTest.java
+++ b/src/test/java/com/zerocracy/radars/github/RbOnBugTest.java
@@ -21,6 +21,7 @@ import com.jcabi.github.Repos;
 import com.jcabi.github.mock.MkGithub;
 import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.fake.FkProject;
+import com.zerocracy.farm.props.PropsFarm;
 import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
@@ -42,7 +43,7 @@ public final class RbOnBugTest {
             .issues().create("bug", "");
         MatcherAssert.assertThat(
             new RbOnBug().react(
-                new FkFarm(new FkProject()),
+                new PropsFarm(new FkFarm(new FkProject())),
                 github,
                 RbOnBugTest.payload(bug)
             ),

--- a/src/test/java/com/zerocracy/radars/github/RbOnCloseTest.java
+++ b/src/test/java/com/zerocracy/radars/github/RbOnCloseTest.java
@@ -22,7 +22,8 @@ import com.jcabi.github.Repo;
 import com.jcabi.github.Repos;
 import com.jcabi.github.mock.MkGithub;
 import com.jcabi.github.mock.MkStorage;
-import com.zerocracy.farm.fake.FkFarm;
+import com.zerocracy.Farm;
+import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pm.ClaimsItem;
 import com.zerocracy.pm.scope.Wbs;
 import java.io.IOException;
@@ -57,7 +58,7 @@ public final class RbOnCloseTest {
         storage.apply(RbOnCloseTest.closeEvent(issue));
         MatcherAssert.assertThat(
             "issue wasn't closed",
-            new RbOnClose().react(new FkFarm(), github, RbOnCloseTest.json(issue)),
+            new RbOnClose().react(new PropsFarm(), github, RbOnCloseTest.json(issue)),
             Matchers.startsWith("Asked WBS")
         );
     }
@@ -74,7 +75,7 @@ public final class RbOnCloseTest {
         );
         issue.close();
         storage.apply(RbOnCloseTest.closeEvent(issue));
-        final FkFarm farm = new FkFarm();
+        final Farm farm = new PropsFarm();
         final GhProject pkt = new GhProject(farm, repo);
         new Wbs(pkt).bootstrap().add(new Job(issue).toString());
         new RbOnClose().react(farm, github, RbOnCloseTest.json(issue));

--- a/src/test/java/com/zerocracy/radars/github/ReQuestionTest.java
+++ b/src/test/java/com/zerocracy/radars/github/ReQuestionTest.java
@@ -23,7 +23,7 @@ import com.jcabi.github.Repo;
 import com.jcabi.github.Repos;
 import com.jcabi.github.mock.MkGithub;
 import com.zerocracy.Farm;
-import com.zerocracy.farm.fake.FkFarm;
+import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pmo.People;
 import org.junit.Test;
 
@@ -45,7 +45,7 @@ public final class ReQuestionTest {
             repo.issues().create("first title", "")
         );
         final Comment comment = issue.comments().post("@0crat hello");
-        final Farm farm = new FkFarm();
+        final Farm farm = new PropsFarm();
         new People(farm).bootstrap().invite(uid, "yegor256");
         new ReQuestion().react(farm, new Comment.Smart(comment));
     }

--- a/src/test/java/com/zerocracy/radars/slack/ReProfileTest.java
+++ b/src/test/java/com/zerocracy/radars/slack/ReProfileTest.java
@@ -20,7 +20,7 @@ import com.ullink.slack.simpleslackapi.SlackChannel;
 import com.ullink.slack.simpleslackapi.SlackUser;
 import com.ullink.slack.simpleslackapi.events.SlackMessagePosted;
 import com.zerocracy.Farm;
-import com.zerocracy.farm.fake.FkFarm;
+import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pm.ClaimIn;
 import com.zerocracy.pm.ClaimsItem;
 import com.zerocracy.pmo.People;
@@ -48,7 +48,7 @@ public final class ReProfileTest {
         final String sid = "U12345678";
         Mockito.doReturn(sid).when(sender).getId();
         Mockito.doReturn(sender).when(event).getSender();
-        final Farm farm = new FkFarm();
+        final Farm farm = new PropsFarm();
         final People people = new People(farm).bootstrap();
         final String uid = "yegor256";
         people.invite(uid, "mentor");
@@ -77,7 +77,7 @@ public final class ReProfileTest {
         final String sid = "U12345679";
         Mockito.doReturn(sid).when(sender).getId();
         Mockito.doReturn(sender).when(event).getSender();
-        final Farm farm = new FkFarm();
+        final Farm farm = new PropsFarm();
         final People people = new People(farm).bootstrap();
         final String uid = "dmarkov";
         people.invite(uid, "mentor1");

--- a/src/test/java/com/zerocracy/tk/project/reports/AwardChampionsTest.java
+++ b/src/test/java/com/zerocracy/tk/project/reports/AwardChampionsTest.java
@@ -19,7 +19,6 @@ package com.zerocracy.tk.project.reports;
 import com.jcabi.xml.XML;
 import com.zerocracy.Project;
 import com.zerocracy.entry.ClaimsOf;
-import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.fake.FkProject;
 import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pm.ClaimOut;
@@ -45,7 +44,7 @@ public final class AwardChampionsTest {
         new ClaimOut().type("Award points were added")
             .param("login", "yegor256")
             .param("points", points)
-            .postTo(new ClaimsOf(new FkFarm(), pkt));
+            .postTo(new ClaimsOf(new PropsFarm(), pkt));
         final XML xml = new ClaimsItem(pkt).iterate().iterator().next();
         try (final Footprint footprint = new Footprint(new PropsFarm(), pkt)) {
             footprint.open(xml);

--- a/src/test/java/com/zerocracy/tk/project/reports/OrderChampionsTest.java
+++ b/src/test/java/com/zerocracy/tk/project/reports/OrderChampionsTest.java
@@ -19,7 +19,6 @@ package com.zerocracy.tk.project.reports;
 import com.jcabi.xml.XML;
 import com.zerocracy.Project;
 import com.zerocracy.entry.ClaimsOf;
-import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.fake.FkProject;
 import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pm.ClaimOut;
@@ -45,7 +44,7 @@ public final class OrderChampionsTest {
         new ClaimOut()
             .type("Order was given")
             .param("login", "yegor256")
-            .postTo(new ClaimsOf(new FkFarm(), pkt));
+            .postTo(new ClaimsOf(new PropsFarm(), pkt));
         final XML xml = new ClaimsItem(pkt).iterate().iterator().next();
         try (final Footprint footprint = new Footprint(new PropsFarm(), pkt)) {
             footprint.open(xml);

--- a/src/test/java/com/zerocracy/tk/project/reports/OrdersGivenByWeekTest.java
+++ b/src/test/java/com/zerocracy/tk/project/reports/OrdersGivenByWeekTest.java
@@ -19,7 +19,6 @@ package com.zerocracy.tk.project.reports;
 import com.jcabi.xml.XML;
 import com.zerocracy.Project;
 import com.zerocracy.entry.ClaimsOf;
-import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.fake.FkProject;
 import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pm.ClaimOut;
@@ -45,7 +44,7 @@ public final class OrdersGivenByWeekTest {
         new ClaimOut()
             .type("Order was given")
             .param("login", "yegor256")
-            .postTo(new ClaimsOf(new FkFarm(), pkt));
+            .postTo(new ClaimsOf(new PropsFarm(), pkt));
         final XML xml = new ClaimsItem(pkt).iterate().iterator().next();
         try (final Footprint footprint = new Footprint(new PropsFarm(), pkt)) {
             footprint.open(xml);
@@ -72,7 +71,7 @@ public final class OrdersGivenByWeekTest {
     public void retrievesEmptyData() throws Exception {
         final Project pkt = new FkProject("746092829");
         new ClaimOut().type("Just hello")
-            .postTo(new ClaimsOf(new FkFarm(), pkt));
+            .postTo(new ClaimsOf(new PropsFarm(), pkt));
         final XML xml = new ClaimsItem(pkt).iterate().iterator().next();
         try (final Footprint footprint = new Footprint(new PropsFarm(), pkt)) {
             footprint.open(xml);

--- a/src/test/resources/com/zerocracy/_props.xml
+++ b/src/test/resources/com/zerocracy/_props.xml
@@ -20,4 +20,8 @@ SOFTWARE.
   Don't add anything here, just use the second argument
   of Props.get().
   -->
+  <sqs>
+    <key>AKIAITHTLXK2FAF747IA</key>
+    <secret>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</secret>
+  </sqs>
 </props>

--- a/src/test/resources/com/zerocracy/_props.xml
+++ b/src/test/resources/com/zerocracy/_props.xml
@@ -20,8 +20,4 @@ SOFTWARE.
   Don't add anything here, just use the second argument
   of Props.get().
   -->
-  <sqs>
-    <key>AKIAITHTLXK2FAF747IA</key>
-    <secret>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</secret>
-  </sqs>
 </props>


### PR DESCRIPTION
#1480 using SQS FIFO queues instead of `claims.xml` file.
 - Added `ClaimsSqs` implementation
 - Using `ClaimsSqs` in `ClaimsOf` if credentials are provided
 - Creating a queue for project if it doesn't exist
 - Added integration tests for SQS queues
 - Added `ValidClaims` to validate claims before submitting to SQS