### PR TITLE
#1179 Enable TkJoinTest.showsThatUserAlreadyHasMentor()

### DIFF
--- a/src/main/java/com/zerocracy/tk/TkJoin.java
+++ b/src/main/java/com/zerocracy/tk/TkJoin.java
@@ -40,7 +40,7 @@ import org.takes.rq.form.RqFormSmart;
  * Join Zerocracy form.
  *
  * @since 1.0
- * @todo #1147:30min Each user should see the status of his/her resume at /join.
+ * @todo #1179:30min Each user should see the status of his/her resume at /join.
  *  If the resume is there, he/she should see the resume, not the form.
  *  See https://github.com/zerocracy/farm/issues/800#issuecomment-375551970
  *  comment for details. This condition is already tested in

--- a/src/main/java/com/zerocracy/tk/TkJoin.java
+++ b/src/main/java/com/zerocracy/tk/TkJoin.java
@@ -42,12 +42,10 @@ import org.takes.rq.form.RqFormSmart;
  * @since 1.0
  * @todo #1147:30min Each user should see the status of his/her resume at /join.
  *  If the resume is there, he/she should see the resume, not the form.
- *  If he/she already has a mentor, there should be a redirect,
- *  saying that "User @yegor256 is already your mentor, no need to join again".
  *  See https://github.com/zerocracy/farm/issues/800#issuecomment-375551970
- *  comment for details. These two conditions are already tested in
- *  TkJoinTest, in showResumeIfAlreadyApplied and showAlreadyHasMentor, and
- *  the ignore tag on the tests should be removed upon puzzle completion.
+ *  comment for details. This condition is already tested in
+ *  TkJoinTest, in showResumeIfAlreadyApplied. If implemented, update the test
+ *  if necessary and the ignore tag should be removed upon puzzle completion.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
@@ -74,7 +72,7 @@ public final class TkJoin implements TkRegex {
             throw new RsForward(
                 new RsParFlash(
                     new Par(
-                        "You already have a mentor (@%s), why again?"
+                        "You already have a mentor (@%s), no need to rejoin."
                     ).say(people.mentor(author)),
                     Level.WARNING
                 ),

--- a/src/test/java/com/zerocracy/tk/TkJoinTest.java
+++ b/src/test/java/com/zerocracy/tk/TkJoinTest.java
@@ -23,6 +23,8 @@ import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pmo.People;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.text.FormattedText;
@@ -167,10 +169,13 @@ public final class TkJoinTest {
                     "Set-Cookie",
                     Matchers.hasItems(
                         Matchers.containsString(
-                            new FormattedText(
-                                "You+already+have+a+mentor+%%28%%40yoda%%29",
-                                mentor
-                            ).asString()
+                            URLEncoder.encode(
+                                new FormattedText(
+                                    "You already have a mentor (@%s)",
+                                    mentor
+                                ).asString(),
+                                StandardCharsets.UTF_8.displayName()
+                            )
                         )
                     )
                 )

--- a/src/test/java/com/zerocracy/tk/TkJoinTest.java
+++ b/src/test/java/com/zerocracy/tk/TkJoinTest.java
@@ -25,9 +25,6 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Date;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.matchers.TextHasString;
-import org.cactoos.text.FormattedText;
-import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.text.StringContainsInOrder;
@@ -135,35 +132,41 @@ public final class TkJoinTest {
 
     /**
      * {@link TkJoin} can show that user already has a mentor.
-     * {@link TkJoin} must show a message to user when he or she tries to access
-     * <code>/join</code> but already has a mentor, which means that the user
-     * has already joined or asked for mentor for joining.
+     * {@link TkJoin} must redirect and show a message to user when he or she
+     * tries to access <code>/join-post</code> but already has a mentor, which
+     * means that the user has already joined or asked for mentor for joining.
      * @throws IOException If something goes wrong accessing page
      */
     @Test
-    @Ignore
+    @SuppressWarnings("unchecked")
     public void showsThatUserAlreadyHasMentor() throws IOException {
         final Farm farm = new PropsFarm(new FkFarm());
         final People people = new People(farm).bootstrap();
-        final String mentorid = "yoda";
-        final String userid = "luke";
-        people.touch(mentorid);
-        people.touch(userid);
-        people.apply(userid, new Date());
-        people.invite(userid, mentorid);
+        final String mentor = "yoda";
+        final String applicant = "luke";
+        people.touch(mentor);
+        people.touch(applicant);
+        people.invite(applicant, mentor, true);
         MatcherAssert.assertThat(
-            new TextOf(
-                new RsPrint(
-                    new TkApp(farm).act(
-                        new RqWithUser(farm, new RqFake("GET", "/join"))
-                    )
-                ).printBody()
+            new TkApp(farm).act(
+                new RqWithBody(
+                    new RqWithUser(
+                        farm,
+                        new RqFake("GET", "/join-post"),
+                        applicant,
+                        false
+                    ),
+                    "personality=INTJ-A&stackoverflow=187242"
+                )
             ),
-            new TextHasString(
-                new FormattedText(
-                    "User %s is already your mentor, no need to join again",
-                    mentorid
-                ).asString()
+            Matchers.allOf(
+                new HmRsStatus(HttpURLConnection.HTTP_SEE_OTHER),
+                new HmRsHeader(
+                    "Set-Cookie",
+                    Matchers.hasItems(
+                        Matchers.containsString(mentor)
+                    )
+                )
             )
         );
     }

--- a/src/test/java/com/zerocracy/tk/TkJoinTest.java
+++ b/src/test/java/com/zerocracy/tk/TkJoinTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Date;
 import org.cactoos.iterable.IterableOf;
+import org.cactoos.text.FormattedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.text.StringContainsInOrder;
@@ -161,10 +162,16 @@ public final class TkJoinTest {
             ),
             Matchers.allOf(
                 new HmRsStatus(HttpURLConnection.HTTP_SEE_OTHER),
+                new HmRsHeader("Location", "/join"),
                 new HmRsHeader(
                     "Set-Cookie",
                     Matchers.hasItems(
-                        Matchers.containsString(mentor)
+                        Matchers.containsString(
+                            new FormattedText(
+                                "You+already+have+a+mentor+%%28%%40yoda%%29",
+                                mentor
+                            ).asString()
+                        )
                     )
                 )
             )


### PR DESCRIPTION
#1179: `TkJoinTest.showsThatUserAlreadyHasMentor()` revised and enabled.

Note to REV/ARC: This seems like a small change for me to do only "half" the puzzle, but the design of `TkJoin` seems to have changed rather significantly from the assumptions of the puzzle. I spent quite a bit of time with the test revisions, so I left the display of the resume for a later puzzle.