### PR TITLE
#721 Fixing Terminator.killer that did not correctly re-submitted itself

### DIFF
--- a/src/main/java/com/zerocracy/farm/sync/Terminator.java
+++ b/src/main/java/com/zerocracy/farm/sync/Terminator.java
@@ -139,9 +139,10 @@ final class Terminator implements Closeable, Scalar<Iterable<Directive>> {
                         Logger.warn(
                             this,
                             // @checkstyle LineLength (1 line)
-                            "Thread disposed. Cancelling terminator for \"%s\" in %s, %s: %[exception]s",
+                            "Thread disposed without proper lock unlock. Unlocking lock for \"%s\" in %s, %s: %[exception]s",
                             file, project.pid(), lock, location
                         );
+                        lock.unlock();
                         this.killers.remove(project);
                     } else {
                         Logger.warn(

--- a/src/main/java/com/zerocracy/farm/sync/Terminator.java
+++ b/src/main/java/com/zerocracy/farm/sync/Terminator.java
@@ -121,12 +121,12 @@ final class Terminator implements Closeable, Scalar<Iterable<Directive>> {
      * @param project The project
      * @param file The file
      * @param lock The lock
-     * @param threadref A weak reference for the Thread that acquired the lock
+     * @param ref A weak reference for the Thread that acquired the lock
      * @return The runnable
      * @checkstyle ParameterNumber (4 lines)
      */
     private Runnable killer(final Project project, final String file,
-        final Lock lock, final WeakReference<Thread> threadref) {
+        final Lock lock, final WeakReference<Thread> ref) {
         final Exception location = new IllegalStateException("Here!");
         return new RunnableOf<Object>(
             input -> {
@@ -134,7 +134,7 @@ final class Terminator implements Closeable, Scalar<Iterable<Directive>> {
                     lock.unlock();
                     this.killers.remove(project);
                 } else {
-                    final Thread thread = threadref.get();
+                    final Thread thread = ref.get();
                     if (thread == null) {
                         Logger.warn(
                             this,
@@ -166,7 +166,7 @@ final class Terminator implements Closeable, Scalar<Iterable<Directive>> {
                         thread.interrupt();
                         this.service.submit(
                             new VerboseRunnable(
-                                this.killer(project, file, lock, threadref),
+                                this.killer(project, file, lock, ref),
                                 true, true
                             )
                         );

--- a/src/test/java/com/zerocracy/farm/sync/TerminatorTest.java
+++ b/src/test/java/com/zerocracy/farm/sync/TerminatorTest.java
@@ -17,6 +17,7 @@
 package com.zerocracy.farm.sync;
 
 import com.jcabi.aspects.Tv;
+import com.zerocracy.Project;
 import com.zerocracy.farm.fake.FkProject;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -32,13 +33,16 @@ import org.mockito.Mockito;
  */
 public final class TerminatorTest {
     /**
-     * Tests that {@link Terminator} implementation, when the
-     * {@link Lock#tryLock()} returns {@code false}, executes again, and calls
-     * {@link Lock#unlock()} only when it acquired the lock by itself.
+     * Terminator can interrupt thread after lock timeout and checks lock again.
+     * Tests that after calling
+     * {@link Terminator#submit(Project, String, Lock)}, if the lock cannot be
+     * acquired by the terminator thread, it will interrupt the thread and
+     * repeat the lock check.
      * @throws Exception if error occurred during test.
      */
     @Test
-    public void runsAgainIfTryLockFail() throws Exception {
+    public void interruptsThreadAfterLockTimeoutAndChecksLockAgain()
+        throws Exception {
         final Lock lock = Mockito.mock(Lock.class);
         Mockito.when(lock.tryLock(Mockito.anyLong(), Mockito.any()))
             .thenReturn(false).thenReturn(true);

--- a/src/test/java/com/zerocracy/farm/sync/TerminatorTest.java
+++ b/src/test/java/com/zerocracy/farm/sync/TerminatorTest.java
@@ -63,11 +63,11 @@ public final class TerminatorTest {
             thread.join();
             Mockito.verify(
                 lock,
-                Mockito.times(2)
+                Mockito.timeout(TimeUnit.SECONDS.toMillis(Tv.FIVE)).times(2)
             ).tryLock(Mockito.anyLong(), Mockito.any());
             Mockito.verify(
                 lock,
-                Mockito.times(1)
+                Mockito.timeout(TimeUnit.SECONDS.toMillis(Tv.FIVE)).times(1)
             ).unlock();
             MatcherAssert.assertThat(
                 interrupted.get(), Matchers.is(true)

--- a/src/test/java/com/zerocracy/farm/sync/TerminatorTest.java
+++ b/src/test/java/com/zerocracy/farm/sync/TerminatorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.farm.sync;
+
+import com.zerocracy.farm.fake.FkProject;
+import java.util.concurrent.locks.Lock;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Test case for {@link Terminator}.
+ * @since 1.0
+ */
+public final class TerminatorTest {
+    /**
+     * Tests that {@link Terminator} implementation, when the
+     * {@link Lock#tryLock()} returns {@code false}, executes again, and calls
+     * {@link Lock#unlock()} only when it acquired the lock by itself.
+     * @throws Exception if error occurred during test.
+     */
+    @Test
+    public void runsAgainIfTryLockFail() throws Exception {
+        final Lock lock = Mockito.mock(Lock.class);
+        Mockito.when(lock.tryLock(Mockito.anyLong(), Mockito.any()))
+            .thenReturn(false).thenReturn(true);
+        final FkProject project = new FkProject();
+        new Thread(
+            () -> new Terminator(1).submit(project, "foo", lock)
+        ).start();
+        // @checkstyle MagicNumber (3 lines)
+        Mockito.verify(lock, Mockito.timeout(20000).times(2))
+            .tryLock(Mockito.anyLong(), Mockito.any());
+        Mockito.verify(lock, Mockito.timeout(10000).times(1)).unlock();
+    }
+}

--- a/src/test/java/com/zerocracy/farm/sync/TerminatorTest.java
+++ b/src/test/java/com/zerocracy/farm/sync/TerminatorTest.java
@@ -38,12 +38,16 @@ public final class TerminatorTest {
         Mockito.when(lock.tryLock(Mockito.anyLong(), Mockito.any()))
             .thenReturn(false).thenReturn(true);
         final FkProject project = new FkProject();
-        new Thread(
-            () -> new Terminator(1).submit(project, "foo", lock)
-        ).start();
-        // @checkstyle MagicNumber (3 lines)
-        Mockito.verify(lock, Mockito.timeout(20000).times(2))
-            .tryLock(Mockito.anyLong(), Mockito.any());
-        Mockito.verify(lock, Mockito.timeout(10000).times(1)).unlock();
+        try (final Terminator terminator = new Terminator(1)) {
+            new Thread(
+                () -> {
+                    terminator.submit(project, "foo", lock);
+                }
+            ).start();
+            // @checkstyle MagicNumber (3 lines)
+            Mockito.verify(lock, Mockito.timeout(10000).times(2))
+                .tryLock(Mockito.anyLong(), Mockito.any());
+            Mockito.verify(lock, Mockito.timeout(10000).times(1)).unlock();
+        }
     }
 }

--- a/src/test/java/com/zerocracy/farm/sync/TerminatorTest.java
+++ b/src/test/java/com/zerocracy/farm/sync/TerminatorTest.java
@@ -49,7 +49,7 @@ public final class TerminatorTest {
         final FkProject project = new FkProject();
         try (final Terminator terminator = new Terminator(1)) {
             final AtomicBoolean interrupted = new AtomicBoolean(false);
-            new Thread(
+            final Thread thread = new Thread(
                 () -> {
                     terminator.submit(project, "foo", lock);
                     try {
@@ -58,17 +58,19 @@ public final class TerminatorTest {
                         interrupted.set(true);
                     }
                 }
-            ).start();
+            );
+            thread.start();
+            thread.join();
             Mockito.verify(
                 lock,
-                Mockito.timeout(TimeUnit.SECONDS.toMillis(Tv.FIVE)).times(2)
+                Mockito.times(2)
             ).tryLock(Mockito.anyLong(), Mockito.any());
             Mockito.verify(
                 lock,
-                Mockito.timeout(TimeUnit.SECONDS.toMillis(Tv.FIVE)).times(1)
+                Mockito.times(1)
             ).unlock();
             MatcherAssert.assertThat(
-                interrupted.get(), Matchers.is(Boolean.TRUE)
+                interrupted.get(), Matchers.is(true)
             );
         }
     }


### PR DESCRIPTION
#721 
There were 2 main problems in Terminator.killer:

1. it called unlock even when lock was not acquired
2. it tries to use  `this.submit(project, file, lock);` to re-submit itself, but it did not work because `this.killers` still contains `project`. And if wasn't for that, it would reference the wrong thread (the terminator thread), instead of the thread that originally called `Terminator.submit`.
