### PR TITLE
#487 Test ping after pr completed does not reassign

### DIFF
--- a/src/test/resources/com/zerocracy/bundles/ping_after_pr_completed/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/ping_after_pr_completed/_after.groovy
@@ -17,11 +17,9 @@
 package com.zerocracy.bundles.close_job_with_quality_review
 
 import com.jcabi.xml.XML
-import com.zerocracy.Farm
 import com.zerocracy.Project
 import com.zerocracy.pm.in.Orders
 import com.zerocracy.pm.scope.Wbs
-import com.zerocracy.pmo.Awards
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 

--- a/src/test/resources/com/zerocracy/bundles/ping_after_pr_completed/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/ping_after_pr_completed/_after.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.close_job_with_quality_review
+
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.pm.in.Orders
+import com.zerocracy.pm.scope.Wbs
+import com.zerocracy.pmo.Awards
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+def exec(Project project, XML xml) {
+  Wbs wbs = new Wbs(project).bootstrap()
+  MatcherAssert.assertThat(wbs.iterate(), Matchers.empty())
+  Orders orders = new Orders(project).bootstrap()
+  MatcherAssert.assertThat(orders.iterate(), Matchers.empty())
+}

--- a/src/test/resources/com/zerocracy/bundles/ping_after_pr_completed/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/ping_after_pr_completed/_after.groovy
@@ -14,7 +14,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.zerocracy.bundles.close_job_with_quality_review
+package com.zerocracy.bundles.ping_after_pr_completed
 
 import com.jcabi.xml.XML
 import com.zerocracy.Project
@@ -24,8 +24,10 @@ import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 
 def exec(Project project, XML xml) {
-  Wbs wbs = new Wbs(project).bootstrap()
-  MatcherAssert.assertThat(wbs.iterate(), Matchers.empty())
-  Orders orders = new Orders(project).bootstrap()
-  MatcherAssert.assertThat(orders.iterate(), Matchers.empty())
+  MatcherAssert.assertThat(
+    new Wbs(project).bootstrap().iterate(), Matchers.empty()
+  )
+  MatcherAssert.assertThat(
+      new Orders(project).bootstrap().iterate(), Matchers.empty()
+  )
 }

--- a/src/test/resources/com/zerocracy/bundles/ping_after_pr_completed/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/ping_after_pr_completed/_before.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.close_job_with_quality_review
+
+import com.jcabi.github.*
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.entry.ExtGithub
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  Github github = new ExtGithub(farm).value()
+  Repo repo = github.repos().create(new Repos.RepoCreate('test', false))
+  new Issue.Smart(
+    new Pull.Smart(repo.pulls().create('PR', 'dev', 'master')).issue()
+  ).close()
+}

--- a/src/test/resources/com/zerocracy/bundles/ping_after_pr_completed/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/ping_after_pr_completed/_before.groovy
@@ -14,7 +14,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.zerocracy.bundles.close_job_with_quality_review
+package com.zerocracy.bundles.ping_after_pr_completed
 
 import com.jcabi.github.*
 import com.jcabi.xml.XML
@@ -24,8 +24,9 @@ import com.zerocracy.entry.ExtGithub
 
 def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
-  Github github = new ExtGithub(farm).value()
-  Repo repo = github.repos().create(new Repos.RepoCreate('test', false))
+  Repo repo = new ExtGithub(farm).value().repos().create(
+    new Repos.RepoCreate('test', false)
+  )
   new Issue.Smart(
     new Pull.Smart(repo.pulls().create('PR', 'dev', 'master')).issue()
   ).close()

--- a/src/test/resources/com/zerocracy/bundles/ping_after_pr_completed/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/ping_after_pr_completed/claims.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.54.2/xsd/pm/claims.xsd" version="0.1" updated="2017-03-27T11:18:09.228Z">
+  <claim id="2">
+    <created>2017-03-27T11:18:09.228Z</created>
+    <type>Add job to WBS</type>
+    <author>manager</author>
+    <token>job;gh:test/test#1</token>
+    <params>
+      <param name="job">gh:test/test#1</param>
+      <param name="role">REV</param>
+    </params>
+  </claim>
+  <claim id="2147483650">
+    <created>2017-03-27T11:18:09.228Z</created>
+    <type>Start order</type>
+    <author>manager</author>
+    <token>job;gh:test/test#1</token>
+    <params>
+      <param name="job">gh:test/test#1</param>
+      <param name="login">reviewer</param>
+      <param name="reason">Just for fun</param>
+    </params>
+  </claim>
+  <claim id="2147483651">
+    <created>2017-03-27T11:18:09.228Z</created>
+    <type>Close job</type>
+    <author>manager</author>
+    <token>job;gh:test/test#1</token>
+    <params>
+      <param name="job">gh:test/test#1</param>
+    </params>
+  </claim>
+  <claim id="2147483652">
+    <created>2017-03-27T11:18:09.228Z</created>
+    <type>Ping</type>
+    <token>job;gh:test/test#1</token>
+    <author>manager</author>
+  </claim>
+</claims>

--- a/src/test/resources/com/zerocracy/bundles/ping_after_pr_completed/roles.xml
+++ b/src/test/resources/com/zerocracy/bundles/ping_after_pr_completed/roles.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<roles xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.54.2/xsd/pm/staff/roles.xsd" version="0.1" updated="2017-03-27T11:18:09.228Z">
+  <person id="manager">
+    <role>ARC</role>
+  </person>
+  <person id="coder">
+    <role>DEV</role>
+  </person>
+  <person id="reviewer">
+    <role>REV</role>
+  </person>
+</roles>


### PR DESCRIPTION
#487 
Checking the footprint provided [here](https://github.com/zerocracy/farm/issues/487#issuecomment-401525930), the problem would be a `Start order` issued after the pr finished and points awarded. Searching current stalkholders, the one that would issue such claim with the attributes in the footprint would be `assign_performer.groovy`. As this stakeholder consumes `Ping` claims, I am creating a test that has a ping claim after the pr completed.