### PR TITLE
Implemented shutdown

### DIFF
--- a/src/main/java/com/zerocracy/claims/ClaimsRoutine.java
+++ b/src/main/java/com/zerocracy/claims/ClaimsRoutine.java
@@ -181,7 +181,7 @@ public final class ClaimsRoutine implements Runnable, Closeable {
 
         @Override
         public void run() {
-            if (!this.shutdown.isStopping()) {
+            if (this.shutdown.check()) {
                 this.origin.run();
             }
         }

--- a/src/main/java/com/zerocracy/farm/sync/SyncFarm.java
+++ b/src/main/java/com/zerocracy/farm/sync/SyncFarm.java
@@ -130,20 +130,9 @@ public final class SyncFarm implements Farm {
     @Override
     public void close() throws IOException {
         try {
-            this.freeze();
             this.terminator.close();
         } finally {
             this.origin.close();
         }
-    }
-
-    /**
-     * Freeze the farm. It will lock all projects so they will stop
-     *  returning new items.
-     * @throws IOException If already called
-     * @checkstyle NonStaticMethodCheck (5 lines)
-     */
-    private void freeze() throws IOException {
-        // not implemented, see SyncFarmTests
     }
 }

--- a/src/main/java/com/zerocracy/shutdown/ShutdownFarm.java
+++ b/src/main/java/com/zerocracy/shutdown/ShutdownFarm.java
@@ -72,17 +72,17 @@ public final class ShutdownFarm implements Farm {
         /**
          * Initial state.
          */
-        private static final String NONE = "none";
+        private static final String ST_NONE = "none";
 
         /**
          * Shutdown in progress.
          */
-        private static final String STOPPING = "stopping";
+        private static final String ST_STOPPING = "stopping";
 
         /**
          * Shutdown completed.
          */
-        private static final String STOPPED = "stopped";
+        private static final String ST_STOPPED = "stopped";
 
         /**
          * Current state.
@@ -93,7 +93,7 @@ public final class ShutdownFarm implements Farm {
          * Default ctor.
          */
         public Hook() {
-            this(new AtomicReference<>(ShutdownFarm.Hook.NONE));
+            this(new AtomicReference<>(ShutdownFarm.Hook.ST_NONE));
         }
 
         /**
@@ -110,13 +110,13 @@ public final class ShutdownFarm implements Farm {
          */
         public void shutdown() {
             if (!this.state.compareAndSet(
-                ShutdownFarm.Hook.NONE, ShutdownFarm.Hook.STOPPING
+                ShutdownFarm.Hook.ST_NONE, ShutdownFarm.Hook.ST_STOPPING
             )) {
                 throw new IllegalStateException(
                     String.format("Cant stop when %s", this.state.get())
                 );
             }
-            while (!ShutdownFarm.Hook.STOPPED.equals(this.state.get())) {
+            while (!ShutdownFarm.Hook.ST_STOPPED.equals(this.state.get())) {
                 try {
                     TimeUnit.SECONDS.sleep(1L);
                 } catch (final InterruptedException ignored) {
@@ -131,15 +131,33 @@ public final class ShutdownFarm implements Farm {
          *
          * @return TRUE if in progress
          */
-        public boolean isStopping() {
-            return !this.state.get().equals(ShutdownFarm.Hook.NONE);
+        public boolean stopping() {
+            return this.state.get().equals(ShutdownFarm.Hook.ST_STOPPING);
+        }
+
+        /**
+         * Check shutdown was completed.
+         *
+         * @return TRUE if stopped
+         */
+        public boolean stopped() {
+            return this.state.get().equals(ShutdownFarm.Hook.ST_STOPPED);
+        }
+
+        /**
+         * Check that shutdown wasn't requested.
+         *
+         * @return TRUE if not requested
+         */
+        public boolean check() {
+            return this.state.get().equals(ShutdownFarm.Hook.ST_NONE);
         }
 
         /**
          * Complete shutdown.
          */
         public void complete() {
-            this.state.set(ShutdownFarm.Hook.STOPPED);
+            this.state.set(ShutdownFarm.Hook.ST_STOPPED);
         }
 
         @Override

--- a/src/main/java/com/zerocracy/shutdown/ShutdownFarm.java
+++ b/src/main/java/com/zerocracy/shutdown/ShutdownFarm.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.shutdown;
+
+import com.zerocracy.Farm;
+import com.zerocracy.Project;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Farm which can shutdown the App.
+ *
+ * @since 1.0
+ */
+public final class ShutdownFarm implements Farm {
+
+    /**
+     * Origin farm.
+     */
+    private final Farm origin;
+
+    /**
+     * Shutdown hook.
+     */
+    private final ShutdownFarm.Hook hook;
+
+    /**
+     * Ctor.
+     *
+     * @param origin Origin farm
+     * @param hook Shutdown hook
+     */
+    public ShutdownFarm(final Farm origin, final ShutdownFarm.Hook hook) {
+        this.origin = origin;
+        this.hook = hook;
+    }
+
+    @Override
+    public Iterable<Project> find(final String xpath) throws IOException {
+        return this.origin.find(xpath);
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            this.hook.shutdown();
+        } finally {
+            this.origin.close();
+        }
+    }
+
+    /**
+     * Shutdown hook.
+     */
+    public static final class Hook {
+
+        /**
+         * Initial state.
+         */
+        private static final String NONE = "none";
+
+        /**
+         * Shutdown in progress.
+         */
+        private static final String STOPPING = "stopping";
+
+        /**
+         * Shutdown completed.
+         */
+        private static final String STOPPED = "stopped";
+
+        /**
+         * Current state.
+         */
+        private final AtomicReference<String> state;
+
+        /**
+         * Default ctor.
+         */
+        public Hook() {
+            this(new AtomicReference<>(ShutdownFarm.Hook.NONE));
+        }
+
+        /**
+         * Primary ctor.
+         *
+         * @param state State
+         */
+        Hook(final AtomicReference<String> state) {
+            this.state = state;
+        }
+
+        /**
+         * Request shutdown.
+         */
+        public void shutdown() {
+            if (!this.state.compareAndSet(
+                ShutdownFarm.Hook.NONE, ShutdownFarm.Hook.STOPPING
+            )) {
+                throw new IllegalStateException(
+                    String.format("Cant stop when %s", this.state.get())
+                );
+            }
+            while (!ShutdownFarm.Hook.STOPPED.equals(this.state.get())) {
+                try {
+                    TimeUnit.SECONDS.sleep(1L);
+                } catch (final InterruptedException ignored) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+
+        /**
+         * Check shutdown in progress.
+         *
+         * @return TRUE if in progress
+         */
+        public boolean isStopping() {
+            return !this.state.get().equals(ShutdownFarm.Hook.NONE);
+        }
+
+        /**
+         * Complete shutdown.
+         */
+        public void complete() {
+            this.state.set(ShutdownFarm.Hook.STOPPED);
+        }
+
+        @Override
+        public String toString() {
+            return this.state.get();
+        }
+    }
+}

--- a/src/main/java/com/zerocracy/shutdown/package-info.java
+++ b/src/main/java/com/zerocracy/shutdown/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * App shutdown.
+ *
+ * @since 1.0
+ */
+package com.zerocracy.shutdown;

--- a/src/test/java/com/zerocracy/claims/ClaimsRoutineITCase.java
+++ b/src/test/java/com/zerocracy/claims/ClaimsRoutineITCase.java
@@ -28,6 +28,7 @@ import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.fake.FkProject;
 import com.zerocracy.farm.props.Props;
 import com.zerocracy.farm.props.PropsFarm;
+import com.zerocracy.shutdown.ShutdownFarm;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -73,7 +74,7 @@ public final class ClaimsRoutineITCase {
                 ).value();
             }
         );
-        routine.start();
+        routine.start(new ShutdownFarm.Hook());
         TimeUnit.SECONDS.sleep((long) Tv.FIVE);
         final String type = "test";
         new ClaimOut()

--- a/src/test/java/com/zerocracy/farm/sync/SyncFarmTest.java
+++ b/src/test/java/com/zerocracy/farm/sync/SyncFarmTest.java
@@ -23,12 +23,9 @@ import com.zerocracy.Item;
 import com.zerocracy.Project;
 import com.zerocracy.RunsInThreads;
 import com.zerocracy.farm.S3Farm;
-import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.pm.scope.Wbs;
 import com.zerocracy.pm.staff.Roles;
-import com.zerocracy.pmo.People;
 import com.zerocracy.pmo.Pmo;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -36,7 +33,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.cactoos.func.RunnableOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -114,21 +110,5 @@ public final class SyncFarmTest {
                 );
             }
         }
-    }
-
-    /**
-     * Shutdown test.
-     * @throws Exception Expected
-     * @todo #476:30min Method freeze should wait for all processed claims,
-     *  and stop giving new claims with IOException,
-     *  it should block all SyncProjects so they stops to
-     *  return SyncItems and wait for all current opened SyncItems to close.
-     */
-    @Test(expected = IOException.class)
-    @Ignore
-    public void freezeAndBlockNewItems() throws Exception {
-        final SyncFarm farm = new SyncFarm(new FkFarm());
-        farm.close();
-        new People(farm).bootstrap();
     }
 }

--- a/src/test/java/com/zerocracy/shutdown/ShutdownFarmTest.java
+++ b/src/test/java/com/zerocracy/shutdown/ShutdownFarmTest.java
@@ -34,12 +34,17 @@ public final class ShutdownFarmTest {
     @Test
     public void shutdown() {
         final ShutdownFarm.Hook hook = new ShutdownFarm.Hook();
+        MatcherAssert.assertThat(
+            "Check failed",
+            hook.check(), Matchers.is(true)
+        );
         final ScheduledExecutorService exec =
             Executors.newSingleThreadScheduledExecutor();
         exec.schedule(hook::complete, 1L, TimeUnit.SECONDS);
         hook.shutdown();
         MatcherAssert.assertThat(
-            hook, Matchers.hasToString("stopped")
+            "Shutdown wasn't completed",
+            hook.stopped(), Matchers.is(true)
         );
     }
 }

--- a/src/test/java/com/zerocracy/shutdown/ShutdownFarmTest.java
+++ b/src/test/java/com/zerocracy/shutdown/ShutdownFarmTest.java
@@ -16,6 +16,8 @@
  */
 package com.zerocracy.shutdown;
 
+import com.zerocracy.Farm;
+import com.zerocracy.farm.fake.FkFarm;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -32,7 +34,7 @@ import org.junit.Test;
 public final class ShutdownFarmTest {
 
     @Test
-    public void shutdown() {
+    public void shutdown() throws Exception {
         final ShutdownFarm.Hook hook = new ShutdownFarm.Hook();
         MatcherAssert.assertThat(
             "Check failed",
@@ -40,8 +42,9 @@ public final class ShutdownFarmTest {
         );
         final ScheduledExecutorService exec =
             Executors.newSingleThreadScheduledExecutor();
+        final Farm farm = new ShutdownFarm(new FkFarm(), hook);
         exec.schedule(hook::complete, 1L, TimeUnit.SECONDS);
-        hook.shutdown();
+        farm.close();
         MatcherAssert.assertThat(
             "Shutdown wasn't completed",
             hook.stopped(), Matchers.is(true)

--- a/src/test/java/com/zerocracy/shutdown/ShutdownFarmTest.java
+++ b/src/test/java/com/zerocracy/shutdown/ShutdownFarmTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.shutdown;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link ShutdownFarm}.
+ *
+ * @since 1.0
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class ShutdownFarmTest {
+
+    @Test
+    public void shutdown() {
+        final ShutdownFarm.Hook hook = new ShutdownFarm.Hook();
+        final ScheduledExecutorService exec =
+            Executors.newSingleThreadScheduledExecutor();
+        exec.schedule(hook::complete, 1L, TimeUnit.SECONDS);
+        hook.shutdown();
+        MatcherAssert.assertThat(
+            hook, Matchers.hasToString("stopped")
+        );
+    }
+}

--- a/src/test/java/com/zerocracy/shutdown/package-info.java
+++ b/src/test/java/com/zerocracy/shutdown/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Tests for shutdown.
+ *
+ * @since 1.0
+ */
+package com.zerocracy.shutdown;


### PR DESCRIPTION
#963 - stop accepting new claims when shutdown called and wait for all submited claims to be processed, then close the farm.