### PR TITLE
For #1506: Show resume in /join if user already has resume.

### DIFF
--- a/src/main/java/com/zerocracy/pmo/Resumes.java
+++ b/src/main/java/com/zerocracy/pmo/Resumes.java
@@ -29,9 +29,10 @@ import org.xembly.Directives;
  * @since 1.0
  *
  * @todo #1506:30min Implement resumes.resume(login), which will return the
- *  resume sent for some user. It will have to return a Map mapping the resume
- *  information so it can be used in resume page. Don't
- *  forget to create a test for it in ResumesTest.
+ *  resume sent for some user. It will have to return a Resume (the interface
+ *  needs to be created, too) object mapping the resume information so it
+ *  can be used in resume page. Don't forget to create a test for it in
+ *  ResumesTest.
  */
 public final class Resumes {
     /**

--- a/src/main/java/com/zerocracy/pmo/Resumes.java
+++ b/src/main/java/com/zerocracy/pmo/Resumes.java
@@ -27,6 +27,11 @@ import org.xembly.Directives;
 /**
  * Resumes.
  * @since 1.0
+ *
+ * @todo #1506:30min Implement resumes.resume(login), which will return the
+ *  resume sent for some user. It will have to return a Map mapping the resume
+ *  information so it can be used in resume page. Don't
+ *  forget to create a test for it in ResumesTest.
  */
 public final class Resumes {
     /**

--- a/src/main/java/com/zerocracy/tk/TkApp.java
+++ b/src/main/java/com/zerocracy/tk/TkApp.java
@@ -163,14 +163,8 @@ public final class TkApp extends TkWrap {
                                                                     new FkRegex("/spam-send", new TkSpam(farm)),
                                                                     new FkRegex("/shutdown", new TkShutdown(props, farm)),
                                                                     new FkRegex("/policy", new TkPolicy()),
-                                                                    new FkRegex(
-                                                                        "/join",
-                                                                        (Take) req -> {
-                                                                            new RqUser(farm, req, false).value();
-                                                                            return new RsPage(farm, "/xsl/join.xsl", req);
-                                                                        }
-                                                                    ),
-                                                                    new FkRegex("/join-post", new TkJoin(farm)),
+                                                                    new FkRegex("/join", new TkJoin(farm)),
+                                                                    new FkRegex("/join-post", new TkJoinPost(farm)),
                                                                     new FkRegex(
                                                                         "/org/takes/.+\\.xsl",
                                                                         new TkClasspath()

--- a/src/main/java/com/zerocracy/tk/TkJoin.java
+++ b/src/main/java/com/zerocracy/tk/TkJoin.java
@@ -17,46 +17,35 @@
 package com.zerocracy.tk;
 
 import com.zerocracy.Farm;
-import com.zerocracy.Par;
-import com.zerocracy.Policy;
-import com.zerocracy.claims.ClaimOut;
-import com.zerocracy.entry.ClaimsOf;
-import com.zerocracy.pmo.People;
-import com.zerocracy.pmo.Resumes;
 import java.io.IOException;
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.util.logging.Level;
 import org.takes.Response;
 import org.takes.facets.fork.RqRegex;
 import org.takes.facets.fork.TkRegex;
-import org.takes.facets.forward.RsForward;
-import org.takes.rq.RqGreedy;
-import org.takes.rq.form.RqFormSmart;
 
 /**
  * Join Zerocracy form.
  *
- * @since 1.0
- * @todo #1179:30min Each user should see the status of his/her resume at /join.
- *  If the resume is there, he/she should see the resume, not the form.
- *  See https://github.com/zerocracy/farm/issues/800#issuecomment-375551970
- *  comment for details. This condition is already tested in
- *  TkJoinTest, in showResumeIfAlreadyApplied. If implemented, update the test
- *  if necessary and the ignore tag should be removed upon puzzle completion.
+ * @since 0.30
+ *
+ * @todo #1506:30min Each user should see the status of his/her resume at /join.
+ *  If the resume is there, he/she should see the resume, not the form. For
+ *  this, a resume page must be implemented in zerocracy-datum (pmo/resume
+ *  .xsl), which will show the resume extracted from Resumes.This condition is
+ *  already tested in TkJoinTest, in showResumeIfAlreadyApplied. When
+ *  implemented, update the test and the ignore tag should be removed upon
+ *  puzzle completion.
+ * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class TkJoin implements TkRegex {
+
     /**
      * Farm.
      */
     private final Farm farm;
 
     /**
-     * Ctor.
+     * Constructor.
      * @param frm Farm
      */
     public TkJoin(final Farm frm) {
@@ -65,90 +54,6 @@ public final class TkJoin implements TkRegex {
 
     @Override
     public Response act(final RqRegex req) throws IOException {
-        final String author = new RqUser(this.farm, req, false).value();
-        final People people = new People(this.farm).bootstrap();
-        people.touch(author);
-        if (people.hasMentor(author)) {
-            throw new RsForward(
-                new RsParFlash(
-                    new Par(
-                        "You already have a mentor (@%s), no need to rejoin."
-                    ).say(people.mentor(author)),
-                    Level.WARNING
-                ),
-                "/join"
-            );
-        }
-        final LocalDateTime when;
-        if (people.applied(author)) {
-            when = LocalDateTime.ofInstant(
-                people.appliedTime(author).toInstant(),
-                ZoneOffset.UTC
-            );
-        } else {
-            when = LocalDateTime.MIN;
-        }
-        final long days = (long) new Policy().get("1.lag", 16);
-        final LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
-        if (when.plusDays(days).isAfter(now)) {
-            throw new RsForward(
-                new RsParFlash(
-                    new Par(
-                        "You can apply only one time in %d days, ",
-                        "you've applied %d days ago (%s)"
-                    ).say(
-                        days,
-                        Duration.between(when, now).toDays(),
-                        when.format(DateTimeFormatter.ISO_LOCAL_DATE)
-                    ),
-                    Level.WARNING
-                ),
-                "/join"
-            );
-        }
-        final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
-        final String telegram = form.single("telegram");
-        final String personality = form.single("personality");
-        final String about = form.single("about");
-        final int stko = Integer.parseInt(form.single("stackoverflow"));
-        new ClaimOut().type("Join form submitted")
-            .author(author)
-            .param("telegram", telegram)
-            .param("stackoverflow", stko)
-            .param("about", about)
-            .param("personality", personality)
-            .postTo(new ClaimsOf(this.farm));
-        new ClaimOut().type("Notify all").param(
-            "message", new Par(
-                "A new user @%s (%s) would like to join us and needs a mentor;",
-                "you can get in touch with him/her",
-                "(telegram: `%s`) to discuss;",
-                "if you become a mentor, you may earn",
-                "some extra income, see §45;",
-                "here are [GitHub](https://github.com/%1$s)",
-                "and [StackOverflow](https://stackoverflow.com/users/%d)",
-                "profiles of the user;",
-                "this is the message the user left for us:\n\n%s"
-            ).say(author, personality, telegram, stko, about)
-        ).param("min", new Policy().get("1.min-rep", 0)).postTo(
-            new ClaimsOf(this.farm)
-        );
-        new Resumes(this.farm).bootstrap()
-            .add(
-                author,
-                LocalDateTime.now(),
-                about,
-                personality,
-                stko,
-                telegram
-            );
-        return new RsForward(
-            new RsParFlash(
-                new Par(
-                    "The request will be sent to all high-ranked users"
-                ).say(),
-                Level.INFO
-            )
-        );
+        return new RsPage(this.farm, "/xsl/join.xsl", req);
     }
 }

--- a/src/main/java/com/zerocracy/tk/TkJoin.java
+++ b/src/main/java/com/zerocracy/tk/TkJoin.java
@@ -25,7 +25,7 @@ import org.takes.facets.fork.TkRegex;
 /**
  * Join Zerocracy form.
  *
- * @since 0.30
+ * @since 1.0
  *
  * @todo #1506:30min Each user should see the status of his/her resume at /join.
  *  If the resume is there, he/she should see the resume, not the form. For

--- a/src/main/java/com/zerocracy/tk/TkJoinPost.java
+++ b/src/main/java/com/zerocracy/tk/TkJoinPost.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.tk;
+
+import com.zerocracy.Farm;
+import com.zerocracy.Par;
+import com.zerocracy.Policy;
+import com.zerocracy.claims.ClaimOut;
+import com.zerocracy.entry.ClaimsOf;
+import com.zerocracy.pmo.People;
+import com.zerocracy.pmo.Resumes;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.logging.Level;
+import org.takes.Response;
+import org.takes.facets.fork.RqRegex;
+import org.takes.facets.fork.TkRegex;
+import org.takes.facets.forward.RsForward;
+import org.takes.rq.RqGreedy;
+import org.takes.rq.form.RqFormSmart;
+
+/**
+ * Join Zerocracy form processing.
+ *
+ * @since 0.30
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+public final class TkJoinPost implements TkRegex {
+    /**
+     * Farm.
+     */
+    private final Farm farm;
+
+    /**
+     * Ctor.
+     * @param frm Farm
+     */
+    public TkJoinPost(final Farm frm) {
+        this.farm = frm;
+    }
+
+    @Override
+    public Response act(final RqRegex req) throws IOException {
+        final String author = new RqUser(this.farm, req, false).value();
+        final People people = new People(this.farm).bootstrap();
+        people.touch(author);
+        if (people.hasMentor(author)) {
+            throw new RsForward(
+                new RsParFlash(
+                    new Par(
+                        "You already have a mentor (@%s), no need to rejoin."
+                    ).say(people.mentor(author)),
+                    Level.WARNING
+                ),
+                "/join"
+            );
+        }
+        final LocalDateTime when;
+        if (people.applied(author)) {
+            when = LocalDateTime.ofInstant(
+                people.appliedTime(author).toInstant(),
+                ZoneOffset.UTC
+            );
+        } else {
+            when = LocalDateTime.MIN;
+        }
+        final long days = (long) new Policy().get("1.lag", 16);
+        final LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+        if (when.plusDays(days).isAfter(now)) {
+            throw new RsForward(
+                new RsParFlash(
+                    new Par(
+                        "You can apply only one time in %d days, ",
+                        "you've applied %d days ago (%s)"
+                    ).say(
+                        days,
+                        Duration.between(when, now).toDays(),
+                        when.format(DateTimeFormatter.ISO_LOCAL_DATE)
+                    ),
+                    Level.WARNING
+                ),
+                "/join"
+            );
+        }
+        final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
+        final String telegram = form.single("telegram");
+        final String personality = form.single("personality");
+        final String about = form.single("about");
+        final int stko = Integer.parseInt(form.single("stackoverflow"));
+        new ClaimOut().type("Join form submitted")
+            .author(author)
+            .param("telegram", telegram)
+            .param("stackoverflow", stko)
+            .param("about", about)
+            .param("personality", personality)
+            .postTo(new ClaimsOf(this.farm));
+        new ClaimOut().type("Notify all").param(
+            "message", new Par(
+                "A new user @%s (%s) would like to join us and needs a mentor;",
+                "you can get in touch with him/her",
+                "(telegram: `%s`) to discuss;",
+                "if you become a mentor, you may earn",
+                "some extra income, see §45;",
+                "here are [GitHub](https://github.com/%1$s)",
+                "and [StackOverflow](https://stackoverflow.com/users/%d)",
+                "profiles of the user;",
+                "this is the message the user left for us:\n\n%s"
+            ).say(author, personality, telegram, stko, about)
+        ).param("min", new Policy().get("1.min-rep", 0)).postTo(
+            new ClaimsOf(this.farm)
+        );
+        new Resumes(this.farm).bootstrap()
+            .add(
+                author,
+                LocalDateTime.now(),
+                about,
+                personality,
+                stko,
+                telegram
+            );
+        return new RsForward(
+            new RsParFlash(
+                new Par(
+                    "The request will be sent to all high-ranked users"
+                ).say(),
+                Level.INFO
+            )
+        );
+    }
+}

--- a/src/main/java/com/zerocracy/tk/TkJoinPost.java
+++ b/src/main/java/com/zerocracy/tk/TkJoinPost.java
@@ -39,7 +39,7 @@ import org.takes.rq.form.RqFormSmart;
 /**
  * Join Zerocracy form processing.
  *
- * @since 0.30
+ * @since 1.0
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
@@ -50,7 +50,7 @@ public final class TkJoinPost implements TkRegex {
     private final Farm farm;
 
     /**
-     * Ctor.
+     * Constructor.
      * @param frm Farm
      */
     public TkJoinPost(final Farm frm) {

--- a/src/main/resources/xsl/resume.xsl
+++ b/src/main/resources/xsl/resume.xsl
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.w3.org/1999/xhtml" version="2.0">
+  <xsl:output method="html" doctype-system="about:legacy-compat" encoding="UTF-8" indent="yes"/>
+  <xsl:strip-space elements="*"/>
+  <xsl:include href="/xsl/inner-layout.xsl"/>
+  <xsl:template match="page" mode="head">
+    <title>
+      <xsl:text>Resume</xsl:text>
+    </title>
+  </xsl:template>
+  <xsl:template match="page" mode="inner">
+    <xsl:value-of select="xml" disable-output-escaping="yes"/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/test/java/com/zerocracy/tk/TkJoinPostTest.java
+++ b/src/test/java/com/zerocracy/tk/TkJoinPostTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.tk;
+
+import com.zerocracy.Farm;
+import com.zerocracy.farm.fake.FkFarm;
+import com.zerocracy.farm.props.PropsFarm;
+import com.zerocracy.pmo.People;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import org.cactoos.text.FormattedText;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.takes.facets.hamcrest.HmRsHeader;
+import org.takes.facets.hamcrest.HmRsStatus;
+import org.takes.rq.RqFake;
+import org.takes.rq.RqWithBody;
+
+/**
+ * Test case for {@link TkJoinPost}.
+ *
+ * @since 0.30
+ * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+public final class TkJoinPostTest {
+
+    @Test
+    public void acceptRequestAndRedirectOnPost() throws Exception {
+        final Farm farm = new PropsFarm(new FkFarm());
+        MatcherAssert.assertThat(
+            new TkApp(farm).act(
+                new RqWithBody(
+                    new RqWithUser(
+                        farm,
+                        new RqFake("POST", "/join-post")
+                    ),
+                    "personality=INTJ-A&stackoverflow=187141"
+                )
+            ),
+            Matchers.allOf(
+                new HmRsStatus(HttpURLConnection.HTTP_SEE_OTHER),
+                new HmRsHeader("Location", "/join")
+            )
+        );
+    }
+
+    @Test
+    public void rejectsIfAlreadyApplied() throws Exception {
+        final Farm farm = new PropsFarm(new FkFarm());
+        final People people = new People(farm).bootstrap();
+        final String uid = "yegor256";
+        people.touch(uid);
+        people.apply(uid, new Date());
+        final RqWithUser req = new RqWithUser(
+            farm,
+            new RqFake("POST", "/join-post")
+        );
+        people.breakup(uid);
+        MatcherAssert.assertThat(
+            new TkApp(farm).act(
+                new RqWithBody(
+                    req,
+                    "personality=INTJ-A&stackoverflow=187241"
+                )
+            ),
+            new HmRsHeader("Set-Cookie", Matchers.iterableWithSize(2))
+        );
+    }
+
+    @Test
+    public void acceptIfNeverApplied() throws Exception {
+        final Farm farm = new PropsFarm(new FkFarm());
+        final People people = new People(farm).bootstrap();
+        final String uid = "yegor256";
+        people.touch(uid);
+        final RqWithUser req = new RqWithUser(
+            farm,
+            new RqFake("POST", "/join-post")
+        );
+        people.breakup(uid);
+        MatcherAssert.assertThat(
+            new TkApp(farm).act(
+                new RqWithBody(
+                    req,
+                    // @checkstyle LineLength (1 line)
+                    "personality=INTJ-A&stackoverflow=187241&telegram=123&about=txt"
+                )
+            ),
+            Matchers.allOf(
+                new HmRsStatus(HttpURLConnection.HTTP_SEE_OTHER),
+                new HmRsHeader("Location", "/")
+            )
+        );
+    }
+
+    /**
+     * {@link TkJoinPost} can show that user already has a mentor.
+     * {@link TkJoinPost} must redirect and show a message to user when he or
+     * she tries to access <code>/join-post</code> but already has a mentor,
+     * which means that the user has already joined or asked for mentor for
+     * joining.
+     * @throws IOException If something goes wrong accessing page
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void showsThatUserAlreadyHasMentor() throws IOException {
+        final Farm farm = new PropsFarm(new FkFarm());
+        final People people = new People(farm).bootstrap();
+        final String mentor = "yoda";
+        final String applicant = "luke";
+        people.touch(mentor);
+        people.touch(applicant);
+        people.invite(applicant, mentor, true);
+        MatcherAssert.assertThat(
+            new TkApp(farm).act(
+                new RqWithBody(
+                    new RqWithUser(
+                        farm,
+                        new RqFake("GET", "/join-post"),
+                        applicant,
+                        false
+                    ),
+                    "personality=INTJ-A&stackoverflow=187242"
+                )
+            ),
+            Matchers.allOf(
+                new HmRsStatus(HttpURLConnection.HTTP_SEE_OTHER),
+                new HmRsHeader("Location", "/join"),
+                new HmRsHeader(
+                    "Set-Cookie",
+                    Matchers.hasItems(
+                        Matchers.containsString(
+                            URLEncoder.encode(
+                                new FormattedText(
+                                    "You already have a mentor (@%s)",
+                                    mentor
+                                ).asString(),
+                                StandardCharsets.UTF_8.displayName()
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+}

--- a/src/test/java/com/zerocracy/tk/TkJoinPostTest.java
+++ b/src/test/java/com/zerocracy/tk/TkJoinPostTest.java
@@ -37,7 +37,7 @@ import org.takes.rq.RqWithBody;
 /**
  * Test case for {@link TkJoinPost}.
  *
- * @since 0.30
+ * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/com/zerocracy/tk/TkJoinTest.java
+++ b/src/test/java/com/zerocracy/tk/TkJoinTest.java
@@ -22,27 +22,19 @@ import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pmo.People;
 import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.text.FormattedText;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.text.StringContainsInOrder;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.takes.facets.hamcrest.HmRsHeader;
-import org.takes.facets.hamcrest.HmRsStatus;
 import org.takes.rq.RqFake;
-import org.takes.rq.RqWithBody;
 import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkJoin}.
  *
- * @since 1.0
+ * @since 0.30
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
@@ -64,129 +56,10 @@ public final class TkJoinTest {
         );
     }
 
-    @Test
-    public void acceptRequestAndRedirectOnPost() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
-        MatcherAssert.assertThat(
-            new TkApp(farm).act(
-                new RqWithBody(
-                    new RqWithUser(
-                        farm,
-                        new RqFake("POST", "/join-post")
-                    ),
-                    "personality=INTJ-A&stackoverflow=187141"
-                )
-            ),
-            Matchers.allOf(
-                new HmRsStatus(HttpURLConnection.HTTP_SEE_OTHER),
-                new HmRsHeader("Location", "/join")
-            )
-        );
-    }
-
-    @Test
-    public void rejectsIfAlreadyApplied() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
-        final People people = new People(farm).bootstrap();
-        final String uid = "yegor256";
-        people.touch(uid);
-        people.apply(uid, new Date());
-        final RqWithUser req = new RqWithUser(
-            farm,
-            new RqFake("POST", "/join-post")
-        );
-        people.breakup(uid);
-        MatcherAssert.assertThat(
-            new TkApp(farm).act(
-                new RqWithBody(
-                    req,
-                    "personality=INTJ-A&stackoverflow=187241"
-                )
-            ),
-            new HmRsHeader("Set-Cookie", Matchers.iterableWithSize(2))
-        );
-    }
-
-    @Test
-    public void acceptIfNeverApplied() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
-        final People people = new People(farm).bootstrap();
-        final String uid = "yegor256";
-        people.touch(uid);
-        final RqWithUser req = new RqWithUser(
-            farm,
-            new RqFake("POST", "/join-post")
-        );
-        people.breakup(uid);
-        MatcherAssert.assertThat(
-            new TkApp(farm).act(
-                new RqWithBody(
-                    req,
-                    // @checkstyle LineLength (1 line)
-                    "personality=INTJ-A&stackoverflow=187241&telegram=123&about=txt"
-                )
-            ),
-            Matchers.allOf(
-                new HmRsStatus(HttpURLConnection.HTTP_SEE_OTHER),
-                new HmRsHeader("Location", "/")
-            )
-        );
-    }
-
     /**
-     * {@link TkJoin} can show that user already has a mentor.
-     * {@link TkJoin} must redirect and show a message to user when he or she
-     * tries to access <code>/join-post</code> but already has a mentor, which
-     * means that the user has already joined or asked for mentor for joining.
-     * @throws IOException If something goes wrong accessing page
-     */
-    @Test
-    @SuppressWarnings("unchecked")
-    public void showsThatUserAlreadyHasMentor() throws IOException {
-        final Farm farm = new PropsFarm(new FkFarm());
-        final People people = new People(farm).bootstrap();
-        final String mentor = "yoda";
-        final String applicant = "luke";
-        people.touch(mentor);
-        people.touch(applicant);
-        people.invite(applicant, mentor, true);
-        MatcherAssert.assertThat(
-            new TkApp(farm).act(
-                new RqWithBody(
-                    new RqWithUser(
-                        farm,
-                        new RqFake("GET", "/join-post"),
-                        applicant,
-                        false
-                    ),
-                    "personality=INTJ-A&stackoverflow=187242"
-                )
-            ),
-            Matchers.allOf(
-                new HmRsStatus(HttpURLConnection.HTTP_SEE_OTHER),
-                new HmRsHeader("Location", "/join"),
-                new HmRsHeader(
-                    "Set-Cookie",
-                    Matchers.hasItems(
-                        Matchers.containsString(
-                            URLEncoder.encode(
-                                new FormattedText(
-                                    "You already have a mentor (@%s)",
-                                    mentor
-                                ).asString(),
-                                StandardCharsets.UTF_8.displayName()
-                            )
-                        )
-                    )
-                )
-            )
-        );
-    }
-
-    /**
-     * {@link TkJoin} can show resume if user already applied.
-     * {@link TkJoin} must show user's resume, if there is one, when user tries
-     * to access <code>/join</code> endpoint.
+     * {@link TkJoinPost} can show resume if user already applied.
+     * {@link TkJoinPost} must show user's resume, if there is one, when
+     * user tries to access <code>/join</code> endpoint.
      * @throws IOException If something goes wrong accessing page
      */
     @Test

--- a/src/test/java/com/zerocracy/tk/TkJoinTest.java
+++ b/src/test/java/com/zerocracy/tk/TkJoinTest.java
@@ -34,7 +34,7 @@ import org.takes.rs.RsPrint;
 /**
  * Test case for {@link TkJoin}.
  *
- * @since 0.30
+ * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */


### PR DESCRIPTION
For #1506: This ticket is too big to be resolved in only 30 minutes, so I've had to break it:
- Added puzzle for creating `Resumes.resume(login)`
- Extracted `/join-post` logic into `TkJoinPost` and left `/join` logic into `TkJoin`
- Fixed `TkApp` according new `TkJoin` and `TkJoinPost` classes
- Added `resume.xsl`
- Added todo for continuing implementation.