### PR TITLE
#1553 Avoid repeated XPath lookups of Orders and Reviews

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pm/in/orders/assign_performer.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/in/orders/assign_performer.groovy
@@ -19,9 +19,9 @@ package com.zerocracy.stk.pm.in.orders
 import com.jcabi.xml.XML
 import com.zerocracy.Farm
 import com.zerocracy.Project
+import com.zerocracy.claims.ClaimIn
 import com.zerocracy.entry.ClaimsOf
 import com.zerocracy.farm.Assume
-import com.zerocracy.claims.ClaimIn
 import com.zerocracy.pm.in.Orders
 import com.zerocracy.pm.qa.Reviews
 import com.zerocracy.pm.scope.Wbs
@@ -32,18 +32,15 @@ def exec(Project project, XML xml) {
   new Assume(project, xml).type('Ping')
   ClaimIn claim = new ClaimIn(xml)
   Wbs wbs = new Wbs(project).bootstrap()
-  Orders orders = new Orders(project).bootstrap()
-  Reviews reviews = new Reviews(project).bootstrap()
+  Collection<String> orders = new Orders(project).bootstrap().iterate()
+  Collection<String> reviews = new Reviews(project).bootstrap().iterate()
   Elections elections = new Elections(project).bootstrap()
   Farm farm = binding.variables.farm
   for (String job : wbs.iterate()) {
-    if (orders.assigned(job)) {
+    if (orders.contains(job) || reviews.contains(job)) {
       continue
     }
     if (!elections.elected(job)) {
-      continue
-    }
-    if (reviews.exists(job)) {
       continue
     }
     String winner = elections.winner(job)

--- a/src/main/groovy/com/zerocracy/stk/pm/staff/elections/elect_performer.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/staff/elections/elect_performer.groovy
@@ -21,10 +21,10 @@ import com.jcabi.xml.XML
 import com.zerocracy.Farm
 import com.zerocracy.Policy
 import com.zerocracy.Project
+import com.zerocracy.claims.ClaimIn
 import com.zerocracy.entry.ClaimsOf
 import com.zerocracy.entry.ExtGithub
 import com.zerocracy.farm.Assume
-import com.zerocracy.claims.ClaimIn
 import com.zerocracy.pm.cost.Boosts
 import com.zerocracy.pm.cost.Ledger
 import com.zerocracy.pm.in.Orders
@@ -36,7 +36,20 @@ import com.zerocracy.pm.staff.ranks.RnkBoost
 import com.zerocracy.pm.staff.ranks.RnkGithubBug
 import com.zerocracy.pm.staff.ranks.RnkGithubMilestone
 import com.zerocracy.pm.staff.ranks.RnkRev
-import com.zerocracy.pm.staff.votes.*
+import com.zerocracy.pm.staff.votes.VsBalance
+import com.zerocracy.pm.staff.votes.VsBanned
+import com.zerocracy.pm.staff.votes.VsBigDebt
+import com.zerocracy.pm.staff.votes.VsHardCap
+import com.zerocracy.pm.staff.votes.VsLosers
+import com.zerocracy.pm.staff.votes.VsNoRoom
+import com.zerocracy.pm.staff.votes.VsOptionsMaxJobs
+import com.zerocracy.pm.staff.votes.VsRandom
+import com.zerocracy.pm.staff.votes.VsRate
+import com.zerocracy.pm.staff.votes.VsReputation
+import com.zerocracy.pm.staff.votes.VsSafe
+import com.zerocracy.pm.staff.votes.VsSpeed
+import com.zerocracy.pm.staff.votes.VsVacation
+import com.zerocracy.pm.staff.votes.VsWorkload
 import com.zerocracy.pmo.Pmo
 
 def exec(Project project, XML xml) {
@@ -52,9 +65,9 @@ def exec(Project project, XML xml) {
   //  before jobs from first project will be assigned to the performer.
   Wbs wbs = new Wbs(project).bootstrap()
   Roles roles = new Roles(project).bootstrap()
-  Orders orders = new Orders(project).bootstrap()
+  Collection<String> orders = new Orders(project).bootstrap().iterate()
   Elections elections = new Elections(project).bootstrap()
-  Reviews reviews = new Reviews(project).bootstrap()
+  Collection<String> reviews = new Reviews(project).bootstrap().iterate()
   Farm farm = binding.variables.farm
   Pmo pmo = new Pmo(farm)
   Github github = new ExtGithub(farm).value()
@@ -71,10 +84,7 @@ def exec(Project project, XML xml) {
       new RnkRev(new Wbs(project).bootstrap())
   ].each { jobs.sort(it) }
   for (String job : jobs) {
-    if (orders.assigned(job)) {
-      continue
-    }
-    if (reviews.exists(job)) {
+    if (orders.contains(job) || reviews.contains(job)) {
       continue
     }
     if (elections.exists(job)) {

--- a/src/main/java/com/zerocracy/pm/qa/Reviews.java
+++ b/src/main/java/com/zerocracy/pm/qa/Reviews.java
@@ -290,6 +290,17 @@ public final class Reviews {
     }
 
     /**
+     * Iterate all jobs under review.
+     * @return List of jobs under review.
+     * @throws IOException If fails
+     */
+    public List<String> iterate() throws IOException {
+        try (final Item reviews = this.item()) {
+            return new Xocument(reviews.path()).xpath("/reviews/review/@job");
+        }
+    }
+
+    /**
      * The item.
      * @return Item
      * @throws IOException If fails

--- a/src/main/java/com/zerocracy/pm/staff/Elections.java
+++ b/src/main/java/com/zerocracy/pm/staff/Elections.java
@@ -60,6 +60,21 @@ public final class Elections {
 
     /**
      * XSLT.
+     * @todo #1553:30min This 'stylesheet' is not merely a document transform,
+     *  but in fact the central mechanism for determining the result of the
+     *  election. Not only is this approach confusing and convoluted, it's
+     *  also very inefficient, since we have to do a XSL transform each and
+     *  every time we want to determine the result of an election. Let's remove
+     *  this XSL transform, and replace it with a programmatic version. What I
+     *  am thinking is to create an inner type, Elections.Result, representing
+     *  a single election. It should contain the following information:
+     *  1) "elected", true if at least one person has a total non-zero vote
+     *  2) "winner", username of person with the highest non-zero vote.
+     *  3) "reason", the reason why the winner won.
+     *  We should replace all usages of XSL Stylesheet with Elections.Result.
+     *  Let's prioritize implementing "elected", since the repeated usage of
+     *  this in assign_performer.groovy and elect_performer.groovy is not
+     *  scalable for increasingly big projects.
      */
     private static final XSL STYLESHEET = XSLDocument.make(
         Elections.class.getResource("to-winner.xsl")

--- a/src/test/java/com/zerocracy/pm/qa/ReviewsTest.java
+++ b/src/test/java/com/zerocracy/pm/qa/ReviewsTest.java
@@ -103,4 +103,22 @@ public final class ReviewsTest {
         );
     }
 
+    @Test
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+    public void fetchesAllReviews() throws Exception {
+        final Reviews reviews = new Reviews(new FkProject()).bootstrap();
+        final String[] jobs =
+            {"gh:zerocracy/farm#200", "gh:zerocracy/farm#201"};
+        for (final String job : jobs) {
+            reviews.add(
+                job, "amihaiemil", "g4s8",
+                new Cash.S("$112"), 1, new Cash.S("$25")
+            );
+        }
+        MatcherAssert.assertThat(
+            reviews.iterate(),
+            Matchers.contains(jobs)
+        );
+    }
+
 }


### PR DESCRIPTION
#1553: Slightly speed up assign_performer.groovy and elect_performer.groovy by loading all Orders and Reviews in-memory to avoid repeated XPath lookups.

Meanwhile, the biggest bottleneck is in `Elections`, because we do a XSL transform in order to get the results of an election. I propose a major change to this in the puzzle that I added.