### PR TITLE
#1448: Cleanup of stale QA jobs.

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pmo/agenda/delete_stale_jobs.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pmo/agenda/delete_stale_jobs.groovy
@@ -7,7 +7,7 @@ import com.zerocracy.entry.ClaimsOf
 import com.zerocracy.farm.Assume
 import com.zerocracy.claims.ClaimIn
 import com.zerocracy.pm.in.Orders
-import com.zerocracy.pm.staff.Roles
+import com.zerocracy.pm.qa.Reviews
 import com.zerocracy.pmo.Agenda
 import com.zerocracy.pmo.People
 import com.zerocracy.pmo.Projects
@@ -27,22 +27,11 @@ def exec(Project pmo, XML xml) {
       if (pid == 'PMO') {
         return
       }
-      if (
-        new Roles(
-            farm.find("@id='${pid}'").iterator().next()
-        ).bootstrap().hasRole('QA')
-      ) {
-        return
-        // @todo #1414:30min Cleanup of stale jobs is disabled for QA roles.
-        //  This is because QA jobs are not in Orders, but in Reviews. This
-        //  causes a bug where QA agenda is removed even though the jobs have
-        //  not completed review yet. For QA roles, get the list of jobs from
-        //  Reviews.findByInspector(). Let's also add a Bundles test case
-        //  where delete_stale_jobs should clean up jobs that are not in
-        //  Reviews and retains those that are still awaiting verdict.
-      }
       orders.addAll(
         new Orders(farm.find("@id='${pid}'")[0]).bootstrap().jobs(login)
+      )
+      orders.addAll(
+        new Reviews(farm.find("@id='${pid}'")[0]).bootstrap().findByInspector(login)
       )
     }
     boolean updated = false

--- a/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_after.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.delete_stale_jobs
+
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.pmo.Agenda
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+import org.hamcrest.collection.IsIterableContainingInAnyOrder
+import org.hamcrest.core.IsCollectionContaining
+import org.hamcrest.core.IsEqual
+import org.hamcrest.core.IsNot
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  Agenda agenda = new Agenda(farm, 'test').bootstrap()
+  MatcherAssert.assertThat(
+    'Did not removed stale job',
+    agenda.jobs(),
+    new IsNot<Collection<String>>(
+      new IsCollectionContaining<>(new IsEqual<>('gh:test/test#1'))
+    )
+  )
+  MatcherAssert.assertThat(
+    'Removed valid job',
+    agenda.jobs(),
+    new IsCollectionContaining<>(new IsEqual<>('gh:test/test#2'))
+  )
+}

--- a/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_after.groovy
@@ -14,7 +14,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.zerocracy.bundles.delete_stale_jobs
+package com.zerocracy.bundles.delete_stale_qa_jobs
 
 import com.jcabi.xml.XML
 import com.zerocracy.Farm
@@ -29,7 +29,7 @@ def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
   Agenda agenda = new Agenda(farm, 'test').bootstrap()
   MatcherAssert.assertThat(
-    'Did not removed stale job',
+    'Did not removed QA stale job',
     agenda.jobs(),
     new IsNot<Collection<String>>(
       new IsCollectionContaining<>(new IsEqual<>('gh:test/test#1'))
@@ -39,5 +39,12 @@ def exec(Project project, XML xml) {
     'Removed valid job',
     agenda.jobs(),
     new IsCollectionContaining<>(new IsEqual<>('gh:test/test#2'))
+  )
+  MatcherAssert.assertThat(
+    'Did not removed DEV stale job',
+    agenda.jobs(),
+    new IsNot<Collection<String>>(
+      new IsCollectionContaining<>(new IsEqual<>('gh:test/test#3'))
+    )
   )
 }

--- a/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_after.groovy
@@ -21,8 +21,6 @@ import com.zerocracy.Farm
 import com.zerocracy.Project
 import com.zerocracy.pmo.Agenda
 import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
-import org.hamcrest.collection.IsIterableContainingInAnyOrder
 import org.hamcrest.core.IsCollectionContaining
 import org.hamcrest.core.IsEqual
 import org.hamcrest.core.IsNot

--- a/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_before.groovy
@@ -14,7 +14,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.zerocracy.bundles.delete_stale_jobs
+package com.zerocracy.bundles.delete_stale_qa_jobs
 
 import com.jcabi.xml.XML
 import com.zerocracy.Farm
@@ -30,6 +30,7 @@ def exec(Project project, XML xml) {
   new Projects(new Pmo(farm), 'test').bootstrap().add('TESTPROJECT')
   new Agenda(farm, 'test').bootstrap().add(farm.find("@id='TESTPROJECT'")[0], 'gh:test/test#1', 'QA')
   new Agenda(farm, 'test').bootstrap().add(farm.find("@id='TESTPROJECT'")[0], 'gh:test/test#2', 'QA')
+  new Agenda(farm, 'test').bootstrap().add(farm.find("@id='TESTPROJECT'")[0], 'gh:test/test#3', 'DEV')
   new Reviews(
     farm.find("@id='TESTPROJECT'")[0]
   ).bootstrap().add('gh:test/test#2','test', 'g4s8', new Cash.S('$10'), 30, new Cash.S('$0'))

--- a/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_before.groovy
@@ -34,4 +34,7 @@ def exec(Project project, XML xml) {
   new Reviews(
     farm.find("@id='TESTPROJECT'")[0]
   ).bootstrap().add('gh:test/test#2','test', 'g4s8', new Cash.S('$10'), 30, new Cash.S('$0'))
+  new Reviews(
+    farm.find("@id='TESTPROJECT'")[0]
+  ).bootstrap().add('gh:test/test#3','test', 'g4s8', new Cash.S('$10'), 30, new Cash.S('$0'))
 }

--- a/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_before.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.delete_stale_jobs
+
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.cash.Cash
+import com.zerocracy.pm.qa.Reviews
+import com.zerocracy.pmo.Agenda
+import com.zerocracy.pmo.Pmo
+import com.zerocracy.pmo.Projects
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  new Projects(new Pmo(farm), 'test').bootstrap().add('TESTPROJECT')
+  new Agenda(farm, 'test').bootstrap().add(farm.find("@id='TESTPROJECT'")[0], 'gh:test/test#1', 'QA')
+  new Agenda(farm, 'test').bootstrap().add(farm.find("@id='TESTPROJECT'")[0], 'gh:test/test#2', 'QA')
+  new Reviews(farm.find("@id='TESTPROJECT'")[0]).bootstrap().add('gh:test/test#2','test', 'g4s8', new Cash.S('$10'), 30, new Cash.S('$0'))
+}

--- a/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_before.groovy
@@ -30,5 +30,7 @@ def exec(Project project, XML xml) {
   new Projects(new Pmo(farm), 'test').bootstrap().add('TESTPROJECT')
   new Agenda(farm, 'test').bootstrap().add(farm.find("@id='TESTPROJECT'")[0], 'gh:test/test#1', 'QA')
   new Agenda(farm, 'test').bootstrap().add(farm.find("@id='TESTPROJECT'")[0], 'gh:test/test#2', 'QA')
-  new Reviews(farm.find("@id='TESTPROJECT'")[0]).bootstrap().add('gh:test/test#2','test', 'g4s8', new Cash.S('$10'), 30, new Cash.S('$0'))
+  new Reviews(
+    farm.find("@id='TESTPROJECT'")[0]
+  ).bootstrap().add('gh:test/test#2','test', 'g4s8', new Cash.S('$10'), 30, new Cash.S('$0'))
 }

--- a/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_before.groovy
@@ -36,5 +36,5 @@ def exec(Project project, XML xml) {
   ).bootstrap().add('gh:test/test#2','test', 'g4s8', new Cash.S('$10'), 30, new Cash.S('$0'))
   new Reviews(
     farm.find("@id='TESTPROJECT'")[0]
-  ).bootstrap().add('gh:test/test#3','test', 'g4s8', new Cash.S('$10'), 30, new Cash.S('$0'))
+  ).bootstrap().add('gh:test/test#3','g4s8', 'test', new Cash.S('$10'), 30, new  Cash.S('$0'))
 }

--- a/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_setup.xml
+++ b/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/_setup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<setup>
+  <pmo>true</pmo>
+</setup>

--- a/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/claims.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.27/xsd/pm/claims.xsd" version="0.1" updated="2017-03-27T11:18:09.228Z">
+  <claim id="1">
+    <type>Ping hourly</type>
+    <author>0crat</author>
+    <created>2017-01-15T01:00:00.000Z</created>
+  </claim>
+</claims>

--- a/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/people.xml
+++ b/src/test/resources/com/zerocracy/bundles/delete_stale_qa_jobs/people.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<people xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.37/xsd/pmo/people.xsd" version="1" updated="2016-12-29T09:03:21.684Z">
+  <person id="test">
+    <mentor>yegor256</mentor>
+  </person>
+</people>


### PR DESCRIPTION
For #1448:
- Corrected `delete_stale_jobs.groovy` for cleaning stale QA jobs
- Added bundle test for this condition