### PR TITLE
#1539 block processing of new claims if old ones are still in flight

### DIFF
--- a/src/main/java/com/zerocracy/claims/proc/CountingProc.java
+++ b/src/main/java/com/zerocracy/claims/proc/CountingProc.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.claims.proc;
+
+import com.amazonaws.services.sqs.model.Message;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.cactoos.Proc;
+
+/**
+ * Count currently processed messages.
+ *
+ * @since 1.0
+ */
+public final class CountingProc implements Proc<Message> {
+
+    /**
+     * Decorated proc.
+     */
+    private final Proc<Message> proc;
+
+    /**
+     * Counter.
+     */
+    private final AtomicInteger count;
+
+    /**
+     * Ctor.
+     *
+     * @param proc Proc being decorated
+     * @param count Counter of executing procedures
+     */
+    public CountingProc(final Proc<Message> proc, final AtomicInteger count) {
+        this.proc = proc;
+        this.count = count;
+    }
+
+    @Override
+    public void exec(final Message input) throws Exception {
+        try {
+            this.count.incrementAndGet();
+            this.proc.exec(input);
+        } finally {
+            this.count.decrementAndGet();
+        }
+    }
+}

--- a/src/main/java/com/zerocracy/entry/Main.java
+++ b/src/main/java/com/zerocracy/entry/Main.java
@@ -150,7 +150,7 @@ public final class Main {
                     ),
                     shutdown
                 ),
-                () -> count.intValue() >= threads
+                () -> count.intValue() < threads
             )
         ) {
             new ExtMongobee(farm).apply();

--- a/src/test/java/com/zerocracy/claims/ClaimsRoutineITCase.java
+++ b/src/test/java/com/zerocracy/claims/ClaimsRoutineITCase.java
@@ -74,7 +74,8 @@ public final class ClaimsRoutineITCase {
                         queue, msg.getReceiptHandle()
                     ), msgs
                 ).value();
-            }
+            },
+            () -> true
         );
         routine.start(new ShutdownFarm.Hook());
         TimeUnit.SECONDS.sleep((long) Tv.FIVE);

--- a/src/test/java/com/zerocracy/claims/proc/CountingProcTest.java
+++ b/src/test/java/com/zerocracy/claims/proc/CountingProcTest.java
@@ -20,7 +20,6 @@ import com.amazonaws.services.sqs.model.Message;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.mockito.Mockito;

--- a/src/test/java/com/zerocracy/claims/proc/CountingProcTest.java
+++ b/src/test/java/com/zerocracy/claims/proc/CountingProcTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.claims.proc;
+
+import com.amazonaws.services.sqs.model.Message;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Test case for {@link CountingProc}.
+ *
+ * @since 1.0
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class CountingProcTest {
+    @Test
+    public void goesToZeroAfterFinish() throws Exception {
+        final AtomicInteger count = new AtomicInteger();
+        new CountingProc(msg -> { }, count).exec(Mockito.mock(Message.class));
+        MatcherAssert.assertThat(
+            count.get(),
+            Matchers.is(0)
+        );
+    }
+
+    @Test
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    public void staysAtOneIfBlocked() throws Exception {
+        final AtomicInteger count = new AtomicInteger();
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch block = new CountDownLatch(1);
+        final CountDownLatch inside = new CountDownLatch(1);
+        new Thread(
+            () -> {
+                try {
+                    start.await();
+                    new CountingProc(
+                        msg -> {
+                            inside.countDown();
+                            block.await();
+                        }, count
+                    ).exec(Mockito.mock(Message.class));
+                    // @checkstyle IllegalCatchCheck (1 line)
+                } catch (final Exception ex) {
+                    throw new IllegalStateException(ex);
+                }
+            }
+        ).start();
+        MatcherAssert.assertThat(
+            count.get(),
+            Matchers.is(0)
+        );
+        start.countDown();
+        inside.await();
+        MatcherAssert.assertThat(
+            count.get(),
+            Matchers.is(1)
+        );
+    }
+}

--- a/src/test/java/com/zerocracy/claims/proc/CountingProcTest.java
+++ b/src/test/java/com/zerocracy/claims/proc/CountingProcTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -36,13 +37,17 @@ public final class CountingProcTest {
         final AtomicInteger count = new AtomicInteger();
         new CountingProc(msg -> { }, count).exec(Mockito.mock(Message.class));
         MatcherAssert.assertThat(
+            "Counter should be 0 after exec finishes.",
             count.get(),
-            Matchers.is(0)
+            new IsEqual<>(0)
         );
     }
 
     @Test
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    // @todo #1539:30min Create a FakeMessage and use it each test where
+    //  a Message is used. An example is in staysAtOneIfBlocked, remove Mockito
+    //  mock and use the newly created fake message.
     public void staysAtOneIfBlocked() throws Exception {
         final AtomicInteger count = new AtomicInteger();
         final CountDownLatch start = new CountDownLatch(1);
@@ -65,14 +70,16 @@ public final class CountingProcTest {
             }
         ).start();
         MatcherAssert.assertThat(
+            "Counter should be 0 before exec starts.",
             count.get(),
-            Matchers.is(0)
+            new IsEqual<>(0)
         );
         start.countDown();
         inside.await();
         MatcherAssert.assertThat(
+            "Counter should be 1 while exec is still running.",
             count.get(),
-            Matchers.is(1)
+            new IsEqual<>(1)
         );
     }
 }


### PR DESCRIPTION
#1539 
* New claims now won't be read from SQS if all the threads processing claims are still working
