### PR TITLE
#1167: Update Xembly to 0.22.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.jcabi.incubator</groupId>
       <artifactId>xembly</artifactId>
-      <version>0.22</version>
+      <version>0.22.1</version>
     </dependency>
     <dependency>
       <groupId>javax.validation</groupId>

--- a/src/test/java/com/zerocracy/pm/FootprintTest.java
+++ b/src/test/java/com/zerocracy/pm/FootprintTest.java
@@ -36,7 +36,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -71,12 +70,6 @@ public final class FootprintTest {
     }
 
     @Test
-    @Ignore
-    // @todo #1050:30min This test is not stable (depending on environment it
-    //  fails in about 5% cases) refactor it to make it stable. Remember to run
-    //  large number of builds to make sure it doesn't fail (at least 100
-    //  builds are needed, maybe more). The trouble is most probably in ExtMongo
-    //  for the fake Mongo instance.
     public void addsInThreads() throws Exception {
         try (final Farm farm = new SyncFarm(new PropsFarm())) {
             MatcherAssert.assertThat(


### PR DESCRIPTION
#1167 
An internal thread-safety bug in Xembly can cause errors when it is used is multiple threads. It was the cause of the [error found during FootprintTest](https://github.com/zerocracy/farm/issues/1167#issuecomment-410485364). This bug was fixed in https://github.com/yegor256/xembly/issues/82 and released in Xembly 0.22.1. This PR updates Xembly to fix this problem.