### PR TITLE
#1567 Extend message visibility timeout of SQS claims messages

### DIFF
--- a/src/main/java/com/zerocracy/claims/ClaimsRoutine.java
+++ b/src/main/java/com/zerocracy/claims/ClaimsRoutine.java
@@ -29,6 +29,7 @@ import com.zerocracy.Farm;
 import com.zerocracy.entry.ExtSqs;
 import com.zerocracy.shutdown.ShutdownFarm;
 import java.io.Closeable;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -139,8 +140,9 @@ public final class ClaimsRoutine implements Runnable, Closeable {
                     .withMessageAttributeNames(
                         "project", "signature", ClaimsRoutine.UNTIL
                     )
-                    // @checkstyle MagicNumber (1 line)
-                    .withVisibilityTimeout(120)
+                    .withVisibilityTimeout(
+                        (int) Duration.ofMinutes(2).getSeconds()
+                    )
                     .withMaxNumberOfMessages(ClaimsRoutine.LIMIT)
             ).getMessages();
             final Set<String> projects = new HashSet<>();

--- a/src/main/java/com/zerocracy/claims/ClaimsRoutine.java
+++ b/src/main/java/com/zerocracy/claims/ClaimsRoutine.java
@@ -139,6 +139,8 @@ public final class ClaimsRoutine implements Runnable, Closeable {
                     .withMessageAttributeNames(
                         "project", "signature", ClaimsRoutine.UNTIL
                     )
+                    // @checkstyle MagicNumber (1 line)
+                    .withVisibilityTimeout(120)
                     .withMaxNumberOfMessages(ClaimsRoutine.LIMIT)
             ).getMessages();
             final Set<String> projects = new HashSet<>();

--- a/src/main/java/com/zerocracy/entry/Main.java
+++ b/src/main/java/com/zerocracy/entry/Main.java
@@ -135,6 +135,7 @@ public final class Main {
                 farm,
                 new AsyncProc(
                     farm,
+                    threads,
                     new DeleteProc(
                         farm,
                         new SentryProc(

--- a/src/main/java/com/zerocracy/entry/Main.java
+++ b/src/main/java/com/zerocracy/entry/Main.java
@@ -134,7 +134,7 @@ public final class Main {
             final ClaimsRoutine claims = new ClaimsRoutine(
                 farm,
                 new AsyncProc(
-                    threads,
+                    farm,
                     new DeleteProc(
                         farm,
                         new SentryProc(


### PR DESCRIPTION
#1567: The issue with the duplicate claims is that we are neglecting the message [visibility timeout](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html). When a message is received, that message will be reserved and not be visible, but it won't be removed until we actually delete it. However, if it is not deleted within the grace period specified by the visibility timeout, it will be visible and may be retrieved again. The default message visibility is 30 seconds, I am not sure what the setting of our queue is but 30 seconds is probably too short to go through the received claims.

I've set the timeout to two minutes. Then, I also added a routine to reset the message visibility timeout for any messages that have not been processed yet. See [here](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/working-with-messages.html#processing-messages-timely-manner) for why I implemented this strategy.

**NOTE:** that the limit for the [`ChangeMessageVisibilityBatch`](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ChangeMessageVisibilityBatch.html) request is 10 messages, which is why the messages are set up that way. I am aware that we are only getting 8 messages at a time in `ClaimsRoutine`, but I want to avoid weird errors later on in case we raise this value.