### PR TITLE
#1100: Auto-assign REV role

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pm/staff/roles/assign_role.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/staff/roles/assign_role.groovy
@@ -77,6 +77,12 @@ def exec(Project project, XML xml) {
       'Role %s was already assigned to @%s; '
     ).say(role, login)
   } else {
+    if (role.equals('DEV')) {
+      claim.copy()
+        .type('Assign Role')
+        .param('role', 'REV')
+        .postTo(new ClaimsOf(farm, project))
+    }
     roles.assign(login, role)
     msg = new Par(
       'Role %s was successfully assigned to @%s,',

--- a/src/main/groovy/com/zerocracy/stk/pm/staff/roles/assign_role.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/staff/roles/assign_role.groovy
@@ -84,9 +84,12 @@ def exec(Project project, XML xml) {
         .postTo(new ClaimsOf(farm, project))
     }
     roles.assign(login, role)
+    String text = 'Role %s was successfully assigned to @%s, see [full list](/a/%s?a=pm/staff/roles) of roles; ';
+    if (role.equals('DEV')) {
+        text = text + 'If you don\'t want this user as \'REV\', use resign REV command'
+    }
     msg = new Par(
-      'Role %s was successfully assigned to @%s,',
-      'see [full list](/a/%s?a=pm/staff/roles) of roles; '
+        text
     ).say(role, login, project.pid())
     claim.copy()
       .type('Role was assigned')

--- a/src/test/resources/com/zerocracy/bundles/assign_role/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/assign_role/_after.groovy
@@ -20,14 +20,24 @@ import com.jcabi.xml.XML
 import com.zerocracy.Project
 import com.zerocracy.pm.staff.Roles
 import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
+import org.hamcrest.core.IsCollectionContaining
+import org.hamcrest.core.IsEqual
 
 def exec(Project project, XML xml) {
   Roles roles = new Roles(project).bootstrap()
   MatcherAssert.assertThat(
-    'DEV roles was not assigned to g4s8',
+    'DEV role was not assigned to g4s8',
     roles.allRoles('g4s8'),
-    Matchers.contains(Matchers.equalTo('DEV'))
+    new IsCollectionContaining<>(
+      new IsEqual('DEV')
+    )
+  )
+  MatcherAssert.assertThat(
+    'REV role was not assigned to g4s8',
+    roles.allRoles('g4s8'),
+    new IsCollectionContaining<>(
+      new IsEqual('REV')
+    )
   )
   // @todo #989:30min MkGithub can't create private repository,
   //  any repository from MkGithub is public, see _before in this test.


### PR DESCRIPTION
For #1100:
- Added test checking if `REV` role is assigned upon `DEV` assignment
- Added code assigning `REV` role upon `DEV` assignment and corrected `PO` message