### PR TITLE
#1534 ExpiryProc

### DIFF
--- a/src/main/java/com/zerocracy/claims/ClaimsRoutine.java
+++ b/src/main/java/com/zerocracy/claims/ClaimsRoutine.java
@@ -137,7 +137,7 @@ public final class ClaimsRoutine implements Runnable, Closeable {
             final List<Message> messages = sqs.receiveMessage(
                 new ReceiveMessageRequest(queue)
                     .withMessageAttributeNames(
-                        "project", "signature", ClaimsRoutine.UNTIL
+                        "project", "signature", ClaimsRoutine.UNTIL, "expires"
                     )
                     .withMaxNumberOfMessages(ClaimsRoutine.LIMIT)
             ).getMessages();

--- a/src/main/java/com/zerocracy/claims/proc/ExpiryProc.java
+++ b/src/main/java/com/zerocracy/claims/proc/ExpiryProc.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.claims.proc;
+
+import com.amazonaws.services.sqs.model.Message;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import org.cactoos.Proc;
+import org.cactoos.time.ZonedDateTimeOf;
+
+/**
+ * Proc that checks for claims expiry.
+ *
+ * @since 1.0
+ * @todo #1534:30min For 'Ping' claims, we should add expiry attribute to SQS
+ *  messages. The expiry period should be 5 minutes after the claim is created.
+ */
+public final class ExpiryProc implements Proc<Message> {
+    /**
+     * Expires attribute.
+     */
+    private static final String KEY_EXPIRES = "expires";
+    /**
+     * Decorated proc.
+     */
+    private final Proc<Message> proc;
+
+    /**
+     * Ctor.
+     * @param origin Original proc
+     */
+    public ExpiryProc(final Proc<Message> origin) {
+        this.proc = origin;
+    }
+
+    @Override
+    public void exec(final Message input) throws Exception {
+        final Map<String, String> attrs = input.getAttributes();
+        if (attrs.containsKey(ExpiryProc.KEY_EXPIRES)) {
+            final ZonedDateTime expiry = new ZonedDateTimeOf(
+                attrs.get(ExpiryProc.KEY_EXPIRES),
+                DateTimeFormatter.ISO_OFFSET_DATE_TIME
+            ).value();
+            if (ZonedDateTime.now().isAfter(expiry)) {
+                return;
+            }
+        }
+        this.proc.exec(input);
+    }
+}

--- a/src/main/java/com/zerocracy/claims/proc/ExpiryProc.java
+++ b/src/main/java/com/zerocracy/claims/proc/ExpiryProc.java
@@ -17,6 +17,7 @@
 package com.zerocracy.claims.proc;
 
 import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.MessageAttributeValue;
 import java.time.Instant;
 import java.util.Map;
 import org.cactoos.Proc;
@@ -49,10 +50,12 @@ public final class ExpiryProc implements Proc<Message> {
 
     @Override
     public void exec(final Message input) throws Exception {
-        final Map<String, String> attrs = input.getAttributes();
+        final Map<String, MessageAttributeValue> attrs =
+            input.getMessageAttributes();
         if (attrs.containsKey(ExpiryProc.KEY_EXPIRES)) {
-            final Instant expiry =
-                Instant.parse(attrs.get(ExpiryProc.KEY_EXPIRES));
+            final Instant expiry = Instant.parse(
+                attrs.get(ExpiryProc.KEY_EXPIRES).getStringValue()
+            );
             if (Instant.now().isAfter(expiry)) {
                 return;
             }

--- a/src/main/java/com/zerocracy/claims/proc/ExpiryProc.java
+++ b/src/main/java/com/zerocracy/claims/proc/ExpiryProc.java
@@ -17,11 +17,9 @@
 package com.zerocracy.claims.proc;
 
 import com.amazonaws.services.sqs.model.Message;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.Instant;
 import java.util.Map;
 import org.cactoos.Proc;
-import org.cactoos.time.ZonedDateTimeOf;
 
 /**
  * Proc that checks for claims expiry.
@@ -35,6 +33,7 @@ public final class ExpiryProc implements Proc<Message> {
      * Expires attribute.
      */
     private static final String KEY_EXPIRES = "expires";
+
     /**
      * Decorated proc.
      */
@@ -52,11 +51,9 @@ public final class ExpiryProc implements Proc<Message> {
     public void exec(final Message input) throws Exception {
         final Map<String, String> attrs = input.getAttributes();
         if (attrs.containsKey(ExpiryProc.KEY_EXPIRES)) {
-            final ZonedDateTime expiry = new ZonedDateTimeOf(
-                attrs.get(ExpiryProc.KEY_EXPIRES),
-                DateTimeFormatter.ISO_OFFSET_DATE_TIME
-            ).value();
-            if (ZonedDateTime.now().isAfter(expiry)) {
+            final Instant expiry =
+                Instant.parse(attrs.get(ExpiryProc.KEY_EXPIRES));
+            if (Instant.now().isAfter(expiry)) {
                 return;
             }
         }

--- a/src/main/java/com/zerocracy/entry/Main.java
+++ b/src/main/java/com/zerocracy/entry/Main.java
@@ -25,6 +25,7 @@ import com.zerocracy.claims.proc.AsyncProc;
 import com.zerocracy.claims.proc.BrigadeProc;
 import com.zerocracy.claims.proc.CountingProc;
 import com.zerocracy.claims.proc.DeleteProc;
+import com.zerocracy.claims.proc.ExpiryProc;
 import com.zerocracy.claims.proc.FootprintProc;
 import com.zerocracy.claims.proc.SentryProc;
 import com.zerocracy.farm.S3Farm;
@@ -137,13 +138,15 @@ public final class Main {
                     threads,
                     new DeleteProc(
                         farm,
-                        new SentryProc(
-                            farm,
-                            new FootprintProc(
+                        new ExpiryProc(
+                            new SentryProc(
                                 farm,
-                                new CountingProc(
-                                    new BrigadeProc(farm),
-                                    count
+                                new FootprintProc(
+                                    farm,
+                                    new CountingProc(
+                                        new BrigadeProc(farm),
+                                        count
+                                    )
                                 )
                             )
                         )

--- a/src/test/java/com/zerocracy/claims/proc/ExpiryProcTest.java
+++ b/src/test/java/com/zerocracy/claims/proc/ExpiryProcTest.java
@@ -17,8 +17,8 @@
 package com.zerocracy.claims.proc;
 
 import com.amazonaws.services.sqs.model.Message;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.hamcrest.MatcherAssert;
@@ -40,8 +40,7 @@ public final class ExpiryProcTest {
             new Message().withAttributes(
                 Collections.singletonMap(
                     "expires",
-                    ZonedDateTime.now().plusDays(1)
-                        .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                    Instant.now().plus(Duration.ofDays(1)).toString()
                 )
             )
         );
@@ -66,8 +65,7 @@ public final class ExpiryProcTest {
             new Message().withAttributes(
                 Collections.singletonMap(
                     "expires",
-                    ZonedDateTime.now().minusMinutes(1)
-                        .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                        Instant.now().minus(Duration.ofMinutes(1)).toString()
                 )
             )
         );

--- a/src/test/java/com/zerocracy/claims/proc/ExpiryProcTest.java
+++ b/src/test/java/com/zerocracy/claims/proc/ExpiryProcTest.java
@@ -17,6 +17,7 @@
 package com.zerocracy.claims.proc;
 
 import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.MessageAttributeValue;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
@@ -37,10 +38,12 @@ public final class ExpiryProcTest {
     public void acceptsNonExpiredMessage() throws Exception {
         final AtomicBoolean result = new AtomicBoolean(false);
         new ExpiryProc((msg) -> result.set(true)).exec(
-            new Message().withAttributes(
+            new Message().withMessageAttributes(
                 Collections.singletonMap(
                     "expires",
-                    Instant.now().plus(Duration.ofDays(1)).toString()
+                    new MessageAttributeValue().withStringValue(
+                        Instant.now().plus(Duration.ofDays(1)).toString()
+                    )
                 )
             )
         );
@@ -62,10 +65,12 @@ public final class ExpiryProcTest {
     public void rejectsExpiredMessage() throws Exception {
         final AtomicBoolean result = new AtomicBoolean(false);
         new ExpiryProc((msg) -> result.set(true)).exec(
-            new Message().withAttributes(
+            new Message().withMessageAttributes(
                 Collections.singletonMap(
                     "expires",
+                    new MessageAttributeValue().withStringValue(
                         Instant.now().minus(Duration.ofMinutes(1)).toString()
+                    )
                 )
             )
         );

--- a/src/test/java/com/zerocracy/claims/proc/ExpiryProcTest.java
+++ b/src/test/java/com/zerocracy/claims/proc/ExpiryProcTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.claims.proc;
+
+import com.amazonaws.services.sqs.model.Message;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link ExpiryProc}.
+ * @since 1.0
+ * @checkstyle JavadocMethod (500 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+public final class ExpiryProcTest {
+
+    @Test
+    public void acceptsNonExpiredMessage() throws Exception {
+        final AtomicBoolean result = new AtomicBoolean(false);
+        new ExpiryProc((msg) -> result.set(true)).exec(
+            new Message().withAttributes(
+                Collections.singletonMap(
+                    "expires",
+                    ZonedDateTime.now().plusDays(1)
+                        .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            result.get(), Matchers.is(true)
+        );
+    }
+
+    @Test
+    public void acceptsMessageWithNoExpiry() throws Exception {
+        final AtomicBoolean result = new AtomicBoolean(false);
+        new ExpiryProc((msg) -> result.set(true)).exec(new Message());
+        MatcherAssert.assertThat(
+            result.get(), Matchers.is(true)
+        );
+    }
+
+    @Test
+    public void rejectsExpiredMessage() throws Exception {
+        final AtomicBoolean result = new AtomicBoolean(false);
+        new ExpiryProc((msg) -> result.set(true)).exec(
+            new Message().withAttributes(
+                Collections.singletonMap(
+                    "expires",
+                    ZonedDateTime.now().minusMinutes(1)
+                        .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            result.get(), Matchers.is(false)
+        );
+    }
+}


### PR DESCRIPTION
#1534: Added `ExpiryProc`, which checks for `expires` attribute in SQS claims messages. If expired, the message is skipped.