### PR TITLE
#1082 properly show underfunded projects

### DIFF
--- a/src/main/resources/xsl/board.xsl
+++ b/src/main/resources/xsl/board.xsl
@@ -124,6 +124,11 @@ SOFTWARE.
                 <xsl:text>no funds</xsl:text>
               </span>
             </xsl:when>
+            <xsl:when test="deficit = 'true'">
+              <span style="color:darkgreen;" title="The project is not properly funded">
+                <xsl:text>no funds</xsl:text>
+              </span>
+            </xsl:when>
             <xsl:otherwise>
               <span style="color:darkgreen;" title="The project is funded">
                 <xsl:value-of select="cash"/>

--- a/src/test/java/com/zerocracy/tk/TkBoardTest.java
+++ b/src/test/java/com/zerocracy/tk/TkBoardTest.java
@@ -27,6 +27,7 @@ import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pm.cost.Ledger;
 import com.zerocracy.pmo.Catalog;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
 /**
@@ -90,6 +91,51 @@ public final class TkBoardTest {
             XhtmlMatchers.hasXPaths(
                 // @checkstyle LineLength (1 line)
                 "//xhtml:span[@title = 'The project has no funds, you will work for free']"
+            )
+        );
+    }
+
+    @Test
+    public void doesNotShowProjectsNegativeBalance() throws Exception {
+        final Farm farm = new PropsFarm(new FkFarm());
+        final Repo repo = new MkGithub().randomRepo();
+        final Project project = farm.find("").iterator().next();
+        final Catalog catalog = new Catalog(farm).bootstrap();
+        catalog.add(project.pid(), "2017/01/AAAABBBBC/");
+        catalog.link(
+            project.pid(),
+            "github",
+            repo.coordinates().repo()
+        );
+        catalog.publish(project.pid(), true);
+        final Ledger ledger = new Ledger(project).bootstrap();
+        final Cash.S liabilities = new Cash.S("$256");
+        final Cash.S funding = new Cash.S("$200");
+        ledger.add(
+            new Ledger.Transaction(
+                funding,
+                "assets", "cash",
+                "income", "sponsor",
+                "There is some funding just arrived"
+            ),
+            new Ledger.Transaction(
+                liabilities,
+                "expenses", "jobs",
+                "liabilities", "debt",
+                "Expenses for jobs done"
+            )
+        );
+        ledger.deficit(true);
+        MatcherAssert.assertThat(
+            ledger.cash().decimal().signum(),
+            new IsEqual<>(-1)
+        );
+        final String html = new View(farm, "/board").html();
+        MatcherAssert.assertThat(
+            html,
+            XhtmlMatchers.hasXPaths(
+                // @checkstyle LineLength (1 line)
+                "//xhtml:span[@title = 'The project is not properly funded' and . = 'no funds']"
             )
         );
     }

--- a/src/test/java/com/zerocracy/tk/TkBoardTest.java
+++ b/src/test/java/com/zerocracy/tk/TkBoardTest.java
@@ -110,14 +110,7 @@ public final class TkBoardTest {
         catalog.publish(project.pid(), true);
         final Ledger ledger = new Ledger(project).bootstrap();
         final Cash.S liabilities = new Cash.S("$256");
-        final Cash.S funding = new Cash.S("$200");
         ledger.add(
-            new Ledger.Transaction(
-                funding,
-                "assets", "cash",
-                "income", "sponsor",
-                "There is some funding just arrived"
-            ),
             new Ledger.Transaction(
                 liabilities,
                 "expenses", "jobs",
@@ -127,11 +120,13 @@ public final class TkBoardTest {
         );
         ledger.deficit(true);
         MatcherAssert.assertThat(
+            "Ledger cash amount should be less than zero.",
             ledger.cash().decimal().signum(),
             new IsEqual<>(-1)
         );
         final String html = new View(farm, "/board").html();
         MatcherAssert.assertThat(
+            "Project with negative ledger cash should be shown as 'no funds'.",
             html,
             XhtmlMatchers.hasXPaths(
                 // @checkstyle LineLength (1 line)


### PR DESCRIPTION
#1082 
All funded projects that have deficit will have a "no funds" displayed instead of negative cash amount.