### PR TITLE
#512: Test for exception on http://www.0crat.com/?PsByFlag=PsGithub

### DIFF
--- a/src/test/java/com/zerocracy/tk/TkAppTest.java
+++ b/src/test/java/com/zerocracy/tk/TkAppTest.java
@@ -23,11 +23,11 @@ import com.jcabi.matchers.XhtmlMatchers;
 import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.props.PropsFarm;
 import java.net.HttpURLConnection;
+import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.StringContains;
 import org.junit.Test;
 import org.takes.Take;
-import org.takes.facets.hamcrest.HmRsStatus;
 import org.takes.http.FtRemote;
 import org.takes.rq.RqFake;
 import org.takes.rq.RqWithHeader;
@@ -80,32 +80,30 @@ public final class TkAppTest {
     // @todo #512:30min 0crat is displaying an error page when trying to use
     //  PsByFlag=PsGithub parameter. This test is triggering this behavior.
     //  Find what is causing it and fix it so this exception screen is not
-    //  displayed anymore and remove expected exception from this test.
+    //  displayed anymore and fix the test below negating
+    //  new StringContains(message) occurences in matchers.
     @Test
     public void redirectOnError() throws Exception {
         final Take take = new TkApp(new PropsFarm(new FkFarm()));
+        final String message = "Internal application error";
         MatcherAssert.assertThat(
             "Could not redirect on error",
-            take.act(new RqFake("GET", "/?PsByFlag=PsGithub")),
-            Matchers.not(
-                new HmRsStatus(
-                    HttpURLConnection.HTTP_OK
-                )
-            )
+            new TextOf(
+                take.act(new RqFake("GET", "/?PsByFlag=PsGithub")).body()
+            ).asString(),
+            new StringContains(message)
         );
         MatcherAssert.assertThat(
             "Could not redirect on error (with code)",
-            take.act(
-                new RqFake(
-                    "GET",
-                    "/?PsByFlag=PsGithub&code=1257b773ba07221e7eb5"
-                )
-            ),
-            Matchers.not(
-                new HmRsStatus(
-                    HttpURLConnection.HTTP_OK
-                )
-            )
+            new TextOf(
+                take.act(
+                    new RqFake(
+                        "GET",
+                        "/?PsByFlag=PsGithub&code=1257b773ba07221e7eb5"
+                    )
+                ).body()
+            ).asString(),
+            new StringContains(message)
         );
     }
 }

--- a/src/test/java/com/zerocracy/tk/TkAppTest.java
+++ b/src/test/java/com/zerocracy/tk/TkAppTest.java
@@ -24,8 +24,10 @@ import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.props.PropsFarm;
 import java.net.HttpURLConnection;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.takes.Take;
+import org.takes.facets.hamcrest.HmRsStatus;
 import org.takes.http.FtRemote;
 import org.takes.rq.RqFake;
 import org.takes.rq.RqWithHeader;
@@ -37,6 +39,7 @@ import org.takes.rs.RsPrint;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class TkAppTest {
 
     @Test
@@ -74,4 +77,35 @@ public final class TkAppTest {
         );
     }
 
+    // @todo #512:30min 0crat is displaying an error page when trying to use
+    //  PsByFlag=PsGithub parameter. This test is triggering this behavior.
+    //  Find what is causing it and fix it so this exception screen is not
+    //  displayed anymore and remove expected exception from this test.
+    @Test(expected = IllegalStateException.class)
+    public void redirectOnError() throws Exception {
+        final Take take = new TkApp(new PropsFarm(new FkFarm()));
+        MatcherAssert.assertThat(
+            "Could not redirect on error",
+            take.act(new RqFake("GET", "/?PsByFlag=PsGithub")),
+            Matchers.not(
+                new HmRsStatus(
+                    HttpURLConnection.HTTP_OK
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            "Could not redirect on error (with code)",
+            take.act(
+                new RqFake(
+                    "GET",
+                    "/?PsByFlag=PsGithub&code=1257b773ba07221e7eb5"
+                )
+            ),
+            Matchers.not(
+                new HmRsStatus(
+                    HttpURLConnection.HTTP_OK
+                )
+            )
+        );
+    }
 }

--- a/src/test/java/com/zerocracy/tk/TkAppTest.java
+++ b/src/test/java/com/zerocracy/tk/TkAppTest.java
@@ -23,9 +23,7 @@ import com.jcabi.matchers.XhtmlMatchers;
 import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.props.PropsFarm;
 import java.net.HttpURLConnection;
-import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.StringContains;
 import org.junit.Test;
 import org.takes.Take;
 import org.takes.http.FtRemote;
@@ -80,30 +78,34 @@ public final class TkAppTest {
     // @todo #512:30min 0crat is displaying an error page when trying to use
     //  PsByFlag=PsGithub parameter. This test is triggering this behavior.
     //  Find what is causing it and fix it so this exception screen is not
-    //  displayed anymore and fix the test below negating
-    //  new StringContains(message) occurences in matchers.
+    //  displayed anymore and uncomment the test below.
     @Test
     public void redirectOnError() throws Exception {
-        final Take take = new TkApp(new PropsFarm(new FkFarm()));
-        final String message = "Internal application error";
-        MatcherAssert.assertThat(
-            "Could not redirect on error",
-            new TextOf(
-                take.act(new RqFake("GET", "/?PsByFlag=PsGithub")).body()
-            ).asString(),
-            new StringContains(message)
-        );
-        MatcherAssert.assertThat(
-            "Could not redirect on error (with code)",
-            new TextOf(
-                take.act(
-                    new RqFake(
-                        "GET",
-                        "/?PsByFlag=PsGithub&code=1257b773ba07221e7eb5"
-                    )
-                ).body()
-            ).asString(),
-            new StringContains(message)
-        );
+    // @checkstyle MethodBodyCommentsCheck (30 lines)
+    //final Take take = new TkApp(new PropsFarm(new FkFarm()));
+    //final String message = "Internal application error";
+    //MatcherAssert.assertThat(
+    //    "Could not redirect on error",
+    //    new TextOf(
+    //        take.act(new RqFake("GET", "/?PsByFlag=PsGithub")).body()
+    //    ).asString(),
+    //    new IsNot<>(
+    //        new StringContains(message)
+    //    )
+    //);
+    //MatcherAssert.assertThat(
+    //    "Could not redirect on error (with code)",
+    //    new TextOf(
+    //        take.act(
+    //            new RqFake(
+    //                "GET",
+    //                "/?PsByFlag=PsGithub&code=1257b773ba07221e7eb5"
+    //            )
+    //        ).body()
+    //    ).asString(),
+    //    new IsNot<>(
+    //        new StringContains(message)
+    //    )
+    //);
     }
 }

--- a/src/test/java/com/zerocracy/tk/TkAppTest.java
+++ b/src/test/java/com/zerocracy/tk/TkAppTest.java
@@ -81,7 +81,7 @@ public final class TkAppTest {
     //  PsByFlag=PsGithub parameter. This test is triggering this behavior.
     //  Find what is causing it and fix it so this exception screen is not
     //  displayed anymore and remove expected exception from this test.
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void redirectOnError() throws Exception {
         final Take take = new TkApp(new PropsFarm(new FkFarm()));
         MatcherAssert.assertThat(

--- a/src/test/java/com/zerocracy/tk/TkAppTest.java
+++ b/src/test/java/com/zerocracy/tk/TkAppTest.java
@@ -23,7 +23,11 @@ import com.jcabi.matchers.XhtmlMatchers;
 import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.props.PropsFarm;
 import java.net.HttpURLConnection;
+import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.core.StringContains;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.takes.Take;
 import org.takes.http.FtRemote;
@@ -78,34 +82,34 @@ public final class TkAppTest {
     // @todo #512:30min 0crat is displaying an error page when trying to use
     //  PsByFlag=PsGithub parameter. This test is triggering this behavior.
     //  Find what is causing it and fix it so this exception screen is not
-    //  displayed anymore and uncomment the test below.
+    //  displayed anymore and un-ingnore the test below.
     @Test
+    @Ignore
     public void redirectOnError() throws Exception {
-    // @checkstyle MethodBodyCommentsCheck (30 lines)
-    //final Take take = new TkApp(new PropsFarm(new FkFarm()));
-    //final String message = "Internal application error";
-    //MatcherAssert.assertThat(
-    //    "Could not redirect on error",
-    //    new TextOf(
-    //        take.act(new RqFake("GET", "/?PsByFlag=PsGithub")).body()
-    //    ).asString(),
-    //    new IsNot<>(
-    //        new StringContains(message)
-    //    )
-    //);
-    //MatcherAssert.assertThat(
-    //    "Could not redirect on error (with code)",
-    //    new TextOf(
-    //        take.act(
-    //            new RqFake(
-    //                "GET",
-    //                "/?PsByFlag=PsGithub&code=1257b773ba07221e7eb5"
-    //            )
-    //        ).body()
-    //    ).asString(),
-    //    new IsNot<>(
-    //        new StringContains(message)
-    //    )
-    //);
+        final Take take = new TkApp(new PropsFarm(new FkFarm()));
+        final String message = "Internal application error";
+        MatcherAssert.assertThat(
+            "Could not redirect on error",
+            new TextOf(
+                take.act(new RqFake("GET", "/?PsByFlag=PsGithub")).body()
+            ).asString(),
+            new IsNot<>(
+                new StringContains(message)
+            )
+        );
+        MatcherAssert.assertThat(
+            "Could not redirect on error (with code)",
+            new TextOf(
+                take.act(
+                    new RqFake(
+                        "GET",
+                        "/?PsByFlag=PsGithub&code=1257b773ba07221e7eb5"
+                    )
+                ).body()
+            ).asString(),
+            new IsNot<>(
+                new StringContains(message)
+            )
+        );
     }
 }


### PR DESCRIPTION
For #512:
- Added test for `GET http://www.0crat.com/?PsByFlag=PsGithub&code=1257b773ba07221e7eb5`
- Added test for `GET http://www.0crat.com/?PsByFlag=PsGithub`
- Left todo for fixes.