### PR TITLE
#1098: Pulse graph for zerocracy.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -442,6 +442,23 @@ SOFTWARE.
       <version>1.9.65</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-transcoder</artifactId>
+      <version>1.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-codec</artifactId>
+      <version>1.8</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>xmlgraphics-commons</artifactId>
+      <version>2.1</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/src/main/java/com/zerocracy/pulse/Pulse.java
+++ b/src/main/java/com/zerocracy/pulse/Pulse.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.pulse;
+
+import java.util.Collections;
+
+/**
+ * Zerocracy pulse info.
+ *
+ * @since 1.0
+ * @todo #1098:30min Wire pulse information from /pulse into Pulse as Ticks.
+ *  See implementation in rultor project on how to initalize Pulse objetcs in
+ *  program start and how to make it Tick every minute to collect execution
+ *  data. Then add SVG created in TkTicks to start page (or wherever the
+ *  pulse bar have to be shown).
+ */
+public interface Pulse {
+
+    /**
+     * Empty.
+     */
+    Pulse EMPTY = new Pulse() {
+        @Override
+        public void add(final Tick tick) {
+            throw new UnsupportedOperationException("#add()");
+        }
+        @Override
+        public Iterable<Tick> ticks() {
+            return Collections.emptyList();
+        }
+        @Override
+        public Iterable<Throwable> error() {
+            return Collections.emptyList();
+        }
+        @Override
+        public void error(final Iterable<Throwable> errors) {
+            throw new UnsupportedOperationException("#error()");
+        }
+    };
+
+    /**
+     * Add new tick.
+     * @param tick The tick
+     */
+    void add(Tick tick);
+
+    /**
+     * Get ticks.
+     * @return Ticks
+     */
+    Iterable<Tick> ticks();
+
+    /**
+     * Most recent exception (or empty).
+     * @return Problems
+     */
+    Iterable<Throwable> error();
+
+    /**
+     * Set recent exception (or empty).
+     * @param errors Errors or empty if none
+     */
+    void error(Iterable<Throwable> errors);
+
+}

--- a/src/main/java/com/zerocracy/pulse/Tick.java
+++ b/src/main/java/com/zerocracy/pulse/Tick.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.pulse;
+
+/**
+ * {@link Pulse} tick.
+ *
+ * @since 1.0
+ */
+public final class Tick {
+
+    /**
+     * When was it started.
+     */
+    private final transient long when;
+
+    /**
+     * Duration.
+     */
+    private final transient long msec;
+
+    /**
+     * Footprint items processed.
+     */
+    private final transient int items;
+
+    /**
+     * Ctor.
+     * @param date When
+     * @param duration Duration in msec
+     * @param total Total processed
+     */
+    public Tick(final long date, final long duration,
+        final int total) {
+        this.when = date;
+        this.msec = duration;
+        this.items = total;
+    }
+
+    /**
+     * Time of start.
+     * @return Time of start
+     */
+    public long start() {
+        return this.when;
+    }
+
+    /**
+     * Duration in msec.
+     * @return Duration
+     */
+    public long duration() {
+        return this.msec;
+    }
+
+    /**
+     * Total processed.
+     * @return Number of footprint items
+     */
+    public int total() {
+        return this.items;
+    }
+
+}

--- a/src/main/java/com/zerocracy/pulse/package-info.java
+++ b/src/main/java/com/zerocracy/pulse/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Pulse.
+ *
+ * @since 1.0
+ */
+package com.zerocracy.pulse;

--- a/src/main/java/com/zerocracy/tk/TkTicks.java
+++ b/src/main/java/com/zerocracy/tk/TkTicks.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.tk;
+
+import com.jcabi.aspects.Tv;
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import com.jcabi.xml.XSL;
+import com.jcabi.xml.XSLDocument;
+import com.zerocracy.pulse.Pulse;
+import com.zerocracy.pulse.Tick;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Iterator;
+import org.apache.batik.transcoder.TranscoderException;
+import org.apache.batik.transcoder.TranscoderInput;
+import org.apache.batik.transcoder.TranscoderOutput;
+import org.apache.batik.transcoder.image.PNGTranscoder;
+import org.takes.Request;
+import org.takes.Response;
+import org.takes.Take;
+import org.takes.rs.RsWithBody;
+import org.takes.rs.RsWithType;
+import org.w3c.dom.Document;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * {@link Take} for {@link Pulse} SVG.
+ *
+ * @since 1.0
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+final class TkTicks implements Take {
+
+    /**
+     * XSLT for pulse render.
+     */
+    private static final XSL PULSE = XSLDocument.make(
+        TkTicks.class.getResourceAsStream("../pulse/pulse.xsl")
+    );
+
+    /**
+     * Pulse.
+     */
+    private final transient Pulse pulse;
+
+    /**
+     * Ctor.
+     * @param pls Pulse
+     */
+    TkTicks(final Pulse pls) {
+        this.pulse = pls;
+    }
+
+    @Override
+    public Response act(final Request req) throws IOException {
+        return new RsWithType(
+            new RsWithBody(this.png()),
+            "image/png"
+        );
+    }
+
+    /**
+     * Make PNG in bytes.
+     * @return Bytes
+     * @throws IOException If fails
+     */
+    private byte[] png() throws IOException {
+        final TranscoderInput input = new TranscoderInput(
+            Document.class.cast(
+                TkTicks.PULSE.transform(this.dirs()).node()
+            )
+        );
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final TranscoderOutput output = new TranscoderOutput(baos);
+        final PNGTranscoder transcoder = new PNGTranscoder();
+        transcoder.addTranscodingHint(
+            PNGTranscoder.KEY_WIDTH, (float) Tv.THOUSAND
+        );
+        transcoder.addTranscodingHint(
+            PNGTranscoder.KEY_HEIGHT, (float) Tv.HUNDRED
+        );
+        try {
+            transcoder.transcode(input, output);
+        } catch (final TranscoderException ex) {
+            throw new IOException(ex);
+        }
+        return baos.toByteArray();
+    }
+
+    /**
+     * Turn ticks into XML.
+     * @return XML
+     */
+    private XML dirs() {
+        final long now = System.currentTimeMillis();
+        final Directives dirs = new Directives().add("pulse");
+        final Iterator<Tick> iterator = this.pulse.ticks().iterator();
+        while (iterator.hasNext()) {
+            final Tick tick = iterator.next();
+            dirs.add("tick")
+                .attr("total", Integer.toString(tick.total()))
+                .attr("start", Long.toString(tick.start() - now))
+                .attr("msec", Long.toString(tick.duration()))
+                .up();
+        }
+        return new XMLDocument(new Xembler(dirs).xmlQuietly());
+    }
+}

--- a/src/main/resources/com/zerocracy/pulse/pulse.xsl
+++ b/src/main/resources/com/zerocracy/pulse/pulse.xsl
@@ -1,0 +1,85 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns="http://www.w3.org/1999/xhtml" version="2.0">
+    <xsl:output method="xml" omit-xml-declaration="yes"/>
+    <xsl:template match="pulse">
+        <xsl:variable name="height" select="5"/>
+        <xsl:variable name="width" select="3600000"/>
+        <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" version="1.1"
+            width="100%" height="100%">
+            <xsl:attribute name="viewBox">
+                <xsl:value-of select="-$width"/>
+                <xsl:text> </xsl:text>
+                <xsl:value-of select="0"/>
+                <xsl:text> </xsl:text>
+                <xsl:value-of select="$width"/>
+                <xsl:text> </xsl:text>
+                <xsl:value-of select="$height"/>
+            </xsl:attribute>
+            <defs>
+                <style type="text/css">
+                    text {
+                        font-size: 1.5;
+                        font-family: monospace;
+                    }
+                </style>
+            </defs>
+            <line x1="{-$width}" y1="{$height}" x2="0" y2="{$height}"
+                stroke="lightgray" stroke-width="4px"
+                vector-effect="non-scaling-stroke"/>
+            <xsl:for-each select="tick">
+                <rect height="{@total + 0.5}"
+                    x="{@start}" y="{$height - @total - 0.5}" fill="#348C62">
+                    <xsl:attribute name="width">
+                        <xsl:choose>
+                            <xsl:when test="@msec &lt; 5000">5000</xsl:when>
+                            <xsl:otherwise><xsl:value-of select="@msec"/></xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:attribute>
+                </rect>
+            </xsl:for-each>
+            <xsl:variable name="age" select="-number(tick[last()]/@start) div 1000"/>
+            <text x="0" y="0" style="text-anchor:middle;"
+                transform="scale(46000,1) translate(-39,1.5)">
+                <xsl:choose>
+                    <xsl:when test="not($age) or $age &gt; 600">
+                        <tspan style="fill:red">
+                            <xsl:text>system outage :( click here</xsl:text>
+                        </tspan>
+                    </xsl:when>
+                    <xsl:when test="$age &gt; 240">
+                        <tspan style="fill:orange">
+                            <xsl:text>temporary out of service</xsl:text>
+                        </tspan>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <tspan style="fill:#348C62">
+                            <xsl:text>all systems work fine</xsl:text>
+                        </tspan>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </text>
+            <text x="0" y="0" style="text-anchor:end;"
+                transform="scale(46000,1) translate(0,1.5)">
+                <xsl:value-of select="format-number($age,'0')"/>
+                <xsl:text> sec</xsl:text>
+            </text>
+        </svg>
+    </xsl:template>
+</xsl:stylesheet>

--- a/src/test/java/com/zerocracy/tk/TkTicksTest.java
+++ b/src/test/java/com/zerocracy/tk/TkTicksTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.tk;
+
+import com.jcabi.aspects.Tv;
+import com.zerocracy.pulse.Pulse;
+import com.zerocracy.pulse.Tick;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import javax.imageio.ImageIO;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.takes.Take;
+import org.takes.rq.RqFake;
+import org.takes.rs.RsPrint;
+
+/**
+ * Tests for {@link TkTicks}.
+ *
+ * @since 1.0
+ */
+public final class TkTicksTest {
+
+    /**
+     * TkSVG can render SVG.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void rendersSvg() throws Exception {
+        final Take home = new TkTicks(
+            // @checkstyle AnonInnerLengthCheck (50 lines)
+            new Pulse() {
+                @Override
+                public void add(final Tick tick) {
+                    throw new UnsupportedOperationException("#add()");
+                }
+                @Override
+                public Iterable<Tick> ticks() {
+                    return Arrays.asList(
+                        new Tick(1L, 1L, 1),
+                        new Tick(2L, 1L, 1)
+                    );
+                }
+                @Override
+                public Iterable<Throwable> error() {
+                    throw new UnsupportedOperationException("#error()");
+                }
+                @Override
+                public void error(final Iterable<Throwable> errors) {
+                    throw new UnsupportedOperationException("#error(..)");
+                }
+            }
+        );
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new RsPrint(home.act(new RqFake())).printBody(baos);
+        final BufferedImage image = ImageIO.read(
+            new ByteArrayInputStream(baos.toByteArray())
+        );
+        MatcherAssert.assertThat(
+            image.getWidth(),
+            Matchers.equalTo(Tv.THOUSAND)
+        );
+    }
+
+    /**
+     * TkSVG can render SVG without ticks.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void rendersSvgWithoutTicks() throws Exception {
+        final Take home = new TkTicks(Pulse.EMPTY);
+        MatcherAssert.assertThat(
+            new RsPrint(home.act(new RqFake())).printBody(),
+            Matchers.notNullValue()
+        );
+    }
+}


### PR DESCRIPTION
For #1098: Pulse graph for Zerocracy (got from `rultor` as suggested)
- Added `Pulse` and `Tick` classes
- Created `TkTicks` and `pulse.xsl` which draws pulse SVG image
- Cretaed `TkTicksTest` to test `TkTicks` behavior
- Added todo for wiring these classes to Zerocracy for collecting pulse info from `/pulse` and displyaing it 