### PR TITLE
#1545: Use SQS batch requests where possible.

### DIFF
--- a/src/main/java/com/zerocracy/claims/BatchClaims.java
+++ b/src/main/java/com/zerocracy/claims/BatchClaims.java
@@ -17,7 +17,6 @@
 package com.zerocracy.claims;
 
 import com.jcabi.xml.XML;
-
 import java.io.Closeable;
 import java.io.IOException;
 
@@ -26,9 +25,10 @@ import java.io.IOException;
  *
  * @since 1.0
  */
-public class BatchClaims implements Claims, Closeable {
+public final class BatchClaims implements Claims, Closeable {
+
     @Override
-    public void submit(XML claim) throws IOException {
+    public void submit(final XML claim) throws IOException {
         throw new UnsupportedOperationException("submit(XML) not implemented");
     }
 

--- a/src/main/java/com/zerocracy/claims/BatchClaims.java
+++ b/src/main/java/com/zerocracy/claims/BatchClaims.java
@@ -24,6 +24,9 @@ import java.io.IOException;
  * Batch processing of {@link Claims}.
  *
  * @since 1.0
+ * @todo #1545:30min Implement BatchClaims for sending claims in batch.
+ *  Assure that maximum batch size is 256KB for each batch and after
+ *  implementation remove expected exception from tests in BatchClaimsTest.
  */
 public final class BatchClaims implements Claims, Closeable {
 

--- a/src/main/java/com/zerocracy/claims/BatchClaims.java
+++ b/src/main/java/com/zerocracy/claims/BatchClaims.java
@@ -30,6 +30,27 @@ import java.io.IOException;
  */
 public final class BatchClaims implements Claims, Closeable {
 
+    /**
+     * Maximum batch size (in KB).
+     */
+    private final int max;
+
+    /**
+     * Default ctor.
+     */
+    BatchClaims() {
+        // @checkstyle MagicNumberCheck (1 line)
+        this(256);
+    }
+
+    /**
+     * Ctor.
+     * @param max Maximum batch size, in KB
+     */
+    BatchClaims(final int max) {
+        this.max = max;
+    }
+
     @Override
     public void submit(final XML claim) throws IOException {
         throw new UnsupportedOperationException("submit(XML) not implemented");
@@ -39,4 +60,13 @@ public final class BatchClaims implements Claims, Closeable {
     public void close() throws IOException {
         throw new UnsupportedOperationException("close() not implemented");
     }
+
+    /**
+     * Return the maximum batch size (in KB) allowed.
+     * @return Maximum batch size (in KB)
+     */
+    public int maximum() {
+        return this.max;
+    }
+
 }

--- a/src/main/java/com/zerocracy/claims/BatchClaims.java
+++ b/src/main/java/com/zerocracy/claims/BatchClaims.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.claims;
+
+import com.jcabi.xml.XML;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Batch processing of {@link Claims}.
+ *
+ * @since 1.0
+ */
+public class BatchClaims implements Claims, Closeable {
+    @Override
+    public void submit(XML claim) throws IOException {
+        throw new UnsupportedOperationException("submit(XML) not implemented");
+    }
+
+    @Override
+    public void close() throws IOException {
+        throw new UnsupportedOperationException("close() not implemented");
+    }
+}

--- a/src/test/java/com/zerocracy/claims/BatchClaimsTest.java
+++ b/src/test/java/com/zerocracy/claims/BatchClaimsTest.java
@@ -30,6 +30,9 @@ import org.xembly.Xembler;
  *
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @todo #1545:30min We should use Fake classes instead of Mocks. So,
+ *  implement another way of testing BatchClaims behavior in this test
+ *  without relying on mockito and mocking.
  */
 @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
 public final class BatchClaimsTest {

--- a/src/test/java/com/zerocracy/claims/BatchClaimsTest.java
+++ b/src/test/java/com/zerocracy/claims/BatchClaimsTest.java
@@ -17,39 +17,34 @@
 package com.zerocracy.claims;
 
 import com.jcabi.aspects.Tv;
-import com.jcabi.xml.XML;
-import com.zerocracy.Farm;
-import com.zerocracy.Item;
-import com.zerocracy.Project;
-import com.zerocracy.Xocument;
-import com.zerocracy.entry.ClaimsOf;
-import com.zerocracy.farm.fake.FkFarm;
-import com.zerocracy.farm.fake.FkProject;
-import org.junit.Test;
-import org.xembly.Directives;
-
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * Tests for {@link BatchClaims}.
  *
  * @since 1.0
+ * @checkstyle JavadocMethodCheck (500 lines)
  */
-public class BatchClaimsTest {
+@SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+public final class BatchClaimsTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void obeyClaimBatchMaxSize()throws IOException {
-        final Project project = new FkProject();
-        final int total = Tv.HUNDRED;
+        final int total = Tv.FIVE;
         final List<ClaimOut> claims = new LinkedList<>();
         for (int idx = 0; idx < total; ++idx) {
             claims.add(new ClaimOut().type("hello my future"));
         }
-        Claims claims = new BatchClaims();
-        for (XML claim : new ClaimsItem(project).iterate()){
-            claims.submit(claim);
+        final BatchClaims batch = Mockito.mock(BatchClaims.class);
+        Mockito.doCallRealMethod().when(batch).close();
+        Mockito.doCallRealMethod().when(batch).submit(Mockito.any());
+        for (final ClaimOut claim : claims) {
+            claim.postTo(batch);
         }
+        Mockito.verify(batch, Mockito.times(Tv.FIVE)).close();
     }
 }

--- a/src/test/java/com/zerocracy/claims/BatchClaimsTest.java
+++ b/src/test/java/com/zerocracy/claims/BatchClaimsTest.java
@@ -34,9 +34,8 @@ public final class BatchClaimsTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void obeyClaimBatchMaxSize()throws IOException {
-        final int total = Tv.FIVE;
         final List<ClaimOut> claims = new LinkedList<>();
-        for (int idx = 0; idx < total; ++idx) {
+        for (int idx = 0; idx < Tv.FIVE; ++idx) {
             claims.add(new ClaimOut().type("hello my future"));
         }
         final BatchClaims batch = Mockito.mock(BatchClaims.class);
@@ -50,9 +49,8 @@ public final class BatchClaimsTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void sendClaimsInBatches()throws IOException {
-        final int total = Tv.FIVE;
         final List<ClaimOut> claims = new LinkedList<>();
-        for (int idx = 0; idx < total; ++idx) {
+        for (int idx = 0; idx < Tv.FIVE; ++idx) {
             claims.add(new ClaimOut());
         }
         final BatchClaims batch = Mockito.mock(BatchClaims.class);

--- a/src/test/java/com/zerocracy/claims/BatchClaimsTest.java
+++ b/src/test/java/com/zerocracy/claims/BatchClaimsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.claims;
+
+import com.jcabi.aspects.Tv;
+import com.jcabi.xml.XML;
+import com.zerocracy.Farm;
+import com.zerocracy.Item;
+import com.zerocracy.Project;
+import com.zerocracy.Xocument;
+import com.zerocracy.entry.ClaimsOf;
+import com.zerocracy.farm.fake.FkFarm;
+import com.zerocracy.farm.fake.FkProject;
+import org.junit.Test;
+import org.xembly.Directives;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Tests for {@link BatchClaims}.
+ *
+ * @since 1.0
+ */
+public class BatchClaimsTest {
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void obeyClaimBatchMaxSize()throws IOException {
+        final Project project = new FkProject();
+        final int total = Tv.HUNDRED;
+        final List<ClaimOut> claims = new LinkedList<>();
+        for (int idx = 0; idx < total; ++idx) {
+            claims.add(new ClaimOut().type("hello my future"));
+        }
+        Claims claims = new BatchClaims();
+        for (XML claim : new ClaimsItem(project).iterate()){
+            claims.submit(claim);
+        }
+    }
+}

--- a/src/test/java/com/zerocracy/claims/BatchClaimsTest.java
+++ b/src/test/java/com/zerocracy/claims/BatchClaimsTest.java
@@ -47,4 +47,20 @@ public final class BatchClaimsTest {
         }
         Mockito.verify(batch, Mockito.times(Tv.FIVE)).close();
     }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void sendClaimsInBatches()throws IOException {
+        final int total = Tv.FIVE;
+        final List<ClaimOut> claims = new LinkedList<>();
+        for (int idx = 0; idx < total; ++idx) {
+            claims.add(new ClaimOut());
+        }
+        final BatchClaims batch = Mockito.mock(BatchClaims.class);
+        Mockito.doCallRealMethod().when(batch).close();
+        Mockito.doCallRealMethod().when(batch).submit(Mockito.any());
+        for (final ClaimOut claim : claims) {
+            claim.postTo(batch);
+        }
+        Mockito.verify(batch, Mockito.times(Tv.THREE)).close();
+    }
 }

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
For #1545: Use SQS batch requests where possible.
- Added `BatchClaims` skeleton
- Added `BatchClaimsTest` which tests how many times `close` method is executed
- Added config file for mocking final classes
- Left todo for `BatchClaims` implementation