### PR TITLE
#1076 Split recharging into its own claim

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pm/cost/funding/recharge_on_deficit.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/cost/funding/recharge_on_deficit.groovy
@@ -17,6 +17,7 @@
 package com.zerocracy.stk.pm.cost.funding
 
 import com.jcabi.xml.XML
+import com.zerocracy.Farm
 import com.zerocracy.Project
 import com.zerocracy.cash.Cash
 import com.zerocracy.claims.ClaimOut
@@ -37,6 +38,7 @@ import java.time.Duration
 def exec(Project project, XML xml) {
   new Assume(project, xml).notPmo()
   new Assume(project, xml).type('Make payment', 'Ping hourly')
+  Farm farm = binding.variables.farm
   Ledger ledger = new Ledger(project).bootstrap()
   Cash cash = ledger.cash()
   Cash locked = new Estimates(project).bootstrap().total()
@@ -46,6 +48,6 @@ def exec(Project project, XML xml) {
     if (!new Props(farm).has('//testing')) {
       recharge.until(Duration.ofMinutes(5))
     }
-    recharge.postTo(new ClaimsOf(binding.variables.farm, project))
+    recharge.postTo(new ClaimsOf(farm, project))
   }
 }

--- a/src/test/resources/com/zerocracy/bundles/recharges_on_deficit/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/recharges_on_deficit/_after.groovy
@@ -14,7 +14,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.zerocracy.bundles.respects_notification_options
+package com.zerocracy.bundles.recharges_on_deficit
 
 import com.jcabi.xml.XML
 import com.mongodb.client.model.Filters

--- a/src/test/resources/com/zerocracy/bundles/recharges_on_deficit/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/recharges_on_deficit/_after.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.respects_notification_options
+
+import com.jcabi.xml.XML
+import com.mongodb.client.model.Filters
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.claims.Footprint
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  new Footprint(farm, project).withCloseable {
+    Footprint footprint ->
+    MatcherAssert.assertThat(
+      'Notifications not received, even if enabled',
+      footprint.collection().find(
+        Filters.and(
+          Filters.eq('project', project.pid()),
+          Filters.eq('type', 'Recharge project')
+        )
+      ),
+      Matchers.not(Matchers.emptyIterable())
+    )
+  }
+}

--- a/src/test/resources/com/zerocracy/bundles/recharges_on_deficit/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/recharges_on_deficit/_before.groovy
@@ -14,38 +14,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.zerocracy.stk.pm.cost.funding
+package com.zerocracy.bundles.respects_notification_options
 
 import com.jcabi.xml.XML
 import com.zerocracy.Project
 import com.zerocracy.cash.Cash
-import com.zerocracy.claims.ClaimOut
-import com.zerocracy.entry.ClaimsOf
-import com.zerocracy.farm.Assume
-import com.zerocracy.farm.props.Props
-import com.zerocracy.pm.cost.Estimates
 import com.zerocracy.pm.cost.Ledger
-import java.time.Duration
 
-/**
- * This stakeholder automatically requests for a recharge the project if it
- * detects a deficit.
- *
- * @param project Project to recharge
- * @param xml Claim
- */
 def exec(Project project, XML xml) {
-  new Assume(project, xml).notPmo()
-  new Assume(project, xml).type('Make payment', 'Ping hourly')
-  Ledger ledger = new Ledger(project).bootstrap()
-  Cash cash = ledger.cash()
-  Cash locked = new Estimates(project).bootstrap().total()
-  if (cash < locked.add(new Cash.S('$16'))) {
-    ClaimOut recharge = new ClaimOut()
-      .type('Recharge project')
-    if (!new Props(farm).has('//testing')) {
-      recharge.until(Duration.ofMinutes(5))
-    }
-    recharge.postTo(new ClaimsOf(binding.variables.farm, project))
-  }
+  new Ledger(project).bootstrap().add(
+    new Ledger.Transaction(
+      new Cash.S('$1000'),
+      'expenses', 'jobs',
+      'liabilities', '@yegor256',
+      'Yegor is super expensive'
+    )
+  )
 }

--- a/src/test/resources/com/zerocracy/bundles/recharges_on_deficit/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/recharges_on_deficit/_before.groovy
@@ -14,7 +14,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.zerocracy.bundles.respects_notification_options
+package com.zerocracy.bundles.recharges_on_deficit
 
 import com.jcabi.xml.XML
 import com.zerocracy.Project

--- a/src/test/resources/com/zerocracy/bundles/recharges_on_deficit/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/recharges_on_deficit/claims.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.2/xsd/pm/claims.xsd" version="0.1" updated="2017-03-27T11:18:09.228Z">
+  <claim id="1">
+    <type>Ping hourly</type>
+    <created>2017-01-15T01:00:00.000Z</created>
+  </claim>
+</claims>


### PR DESCRIPTION
#1076: Previously, recharging the project is triggered by `Make payment` and `Ping hourly` claims, which then recharges if the project is under deficit.

I separated the actual recharge into a new claim, `Recharge project`, which is handled by its own stakeholder.  Now the original `recharge_on_deficit` stakeholder checks for deficit only, and generates a _new_ claim (not a copy) to `Recharge project` with a delay of 5 minutes. This should avoid duplicate recharging.