### PR TITLE
#1569: Resumes.resume(login) implementation.

### DIFF
--- a/src/main/java/com/zerocracy/pmo/Resume.java
+++ b/src/main/java/com/zerocracy/pmo/Resume.java
@@ -16,7 +16,7 @@
  */
 package com.zerocracy.pmo;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 /**
  * Resume.
@@ -30,7 +30,7 @@ public interface Resume {
      * Time of resume submission.
      * @return Time of resume submission
      */
-    LocalDateTime submitted();
+    Instant submitted();
 
     /**
      * Login of user which sent the resume.
@@ -70,7 +70,7 @@ public interface Resume {
         /**
         * Resume submission date time.
         */
-        private final LocalDateTime time;
+        private final Instant time;
 
         /**
         * Resume user.
@@ -108,7 +108,7 @@ public interface Resume {
          * @param tele Telegram login of resume user
          * @checkstyle ParameterNumberCheck (10 lines)
          */
-        public Fake(final LocalDateTime time, final String user,
+        public Fake(final Instant time, final String user,
             final String txt, final String person, final long id,
             final String tele) {
             this.time = time;
@@ -120,7 +120,7 @@ public interface Resume {
         }
 
         @Override
-        public LocalDateTime submitted() {
+        public Instant submitted() {
             return this.time;
         }
 

--- a/src/main/java/com/zerocracy/pmo/Resume.java
+++ b/src/main/java/com/zerocracy/pmo/Resume.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.pmo;
+
+import java.time.LocalDateTime;
+
+/**
+ * Resume.
+ *
+ * @since 1.0
+ */
+@SuppressWarnings("PMD.TooManyMethods")
+public interface Resume {
+
+    /**
+     * Time of resume submission.
+     * @return Time of resume submission
+     */
+    LocalDateTime submitted();
+
+    /**
+     * Login of user which sent the resume.
+     * @return Login of user
+     */
+    String login();
+
+    /**
+     * Text of the resume.
+     * @return Text of the resume
+     */
+    String text();
+
+    /**
+     * Personality type of the resume sender.
+     * @return Personality type as a {@link String}
+     */
+    String personality();
+
+    /**
+     * Stack overflow id of the user.
+     * @return Stack overflow id
+     */
+    long soid();
+
+    /**
+     * Telegram login of the user.
+     * @return Telegram login
+     */
+    String telegram();
+
+    /**
+     * Fake implementation for {@link Resume}.
+     */
+    class Fake implements Resume {
+
+        /**
+        * Resume submission date time.
+        */
+        private final LocalDateTime time;
+
+        /**
+        * Resume user.
+        */
+        private final String user;
+
+        /**
+        * Resume text.
+        */
+        private final String txt;
+
+        /**
+        * Resume personality.
+        */
+        private final String person;
+
+        /**
+        * Stack overflow id.
+        */
+        private final long id;
+
+        /**
+        * Telegram login.
+        */
+        private final String tele;
+
+        /**
+         * Constructor.
+         *
+         * @param time Time of resume submission
+         * @param user Login of resume user
+         * @param txt Text of resume
+         * @param person Personality of resume
+         * @param id Stackoverflow id of resume user
+         * @param tele Telegram login of resume user
+         * @checkstyle ParameterNumberCheck (10 lines)
+         */
+        public Fake(final LocalDateTime time, final String user,
+            final String txt, final String person, final long id,
+            final String tele) {
+            this.time = time;
+            this.user = user;
+            this.txt = txt;
+            this.person = person;
+            this.id = id;
+            this.tele = tele;
+        }
+
+        @Override
+        public LocalDateTime submitted() {
+            return this.time;
+        }
+
+        @Override
+        public String login() {
+            return this.user;
+        }
+
+        @Override
+        public String text() {
+            return this.txt;
+        }
+
+        @Override
+        public String personality() {
+            return this.person;
+        }
+
+        @Override
+        public long soid() {
+            return this.id;
+        }
+
+        @Override
+        public String telegram() {
+            return this.tele;
+        }
+    }
+}

--- a/src/main/java/com/zerocracy/pmo/Resumes.java
+++ b/src/main/java/com/zerocracy/pmo/Resumes.java
@@ -29,9 +29,11 @@ import org.xembly.Directives;
  * @since 1.0
  *
  * @todo #1569:30min Implement resumes.resume(login), which will return the
- *  resume sent for some user. It will have to return a Resume (the interface
- *  needs to be created, too) object mapping the resume information so it
- *  can be used in resume page. Then remove expected from ResumesTest.findResume
+ *  resume sent for some user. It will have to return a Resume
+ *  implementation which reads the resume from resumes.xml. It must read
+ *  /resumes/resume attributes and return them in its methods.
+ *  Then remove expected from ResumesTest.findResume so it can be tested to
+ *  be used in resume page.
  */
 public final class Resumes {
     /**

--- a/src/main/java/com/zerocracy/pmo/Resumes.java
+++ b/src/main/java/com/zerocracy/pmo/Resumes.java
@@ -28,11 +28,10 @@ import org.xembly.Directives;
  * Resumes.
  * @since 1.0
  *
- * @todo #1506:30min Implement resumes.resume(login), which will return the
+ * @todo #1569:30min Implement resumes.resume(login), which will return the
  *  resume sent for some user. It will have to return a Resume (the interface
  *  needs to be created, too) object mapping the resume information so it
- *  can be used in resume page. Don't forget to create a test for it in
- *  ResumesTest.
+ *  can be used in resume page. Then remove expected from ResumesTest.findResume
  */
 public final class Resumes {
     /**

--- a/src/main/java/com/zerocracy/pmo/Resumes.java
+++ b/src/main/java/com/zerocracy/pmo/Resumes.java
@@ -161,6 +161,17 @@ public final class Resumes {
     }
 
     /**
+     * Returns the {@link Resume} from user.
+     *
+     * @param login Resume author login
+     * @return Resume from author
+     * @throws IOException If fails or resume not found
+     */
+    public Resume resume(final String login) throws IOException {
+        throw new UnsupportedOperationException("resume() not implemented");
+    }
+
+    /**
      * The item.
      * @return Item
      * @throws IOException If fails

--- a/src/test/java/com/zerocracy/pmo/ResumesTest.java
+++ b/src/test/java/com/zerocracy/pmo/ResumesTest.java
@@ -27,6 +27,7 @@ import java.time.LocalTime;
 import java.time.Month;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
 /**
@@ -99,6 +100,42 @@ public final class ResumesTest {
         MatcherAssert.assertThat(
             resumes.unassigned(),
             Matchers.contains(first)
+        );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void findResume() throws Exception {
+        final Farm farm = new FkFarm();
+        final String login = "login";
+        final LocalDateTime time = LocalDateTime.of(
+            LocalDate.of(2018, Month.JANUARY, 1),
+            LocalTime.of(0, 0)
+        );
+        final String text = "Resume text";
+        final String personality = "ENTP-T";
+        final int id = 187141;
+        final String telegram = "telegram";
+        final Resume fake = new Resume.Fake(
+            time,
+            login,
+            text,
+            personality,
+            id,
+            telegram
+        );
+        final Resumes resumes = new Resumes(farm).bootstrap();
+        resumes.add(
+            login,
+            time,
+            text,
+            personality,
+            id,
+            telegram
+        );
+        MatcherAssert.assertThat(
+            "Could not find resume",
+            resumes.resume(login),
+            new IsEqual<>(fake)
         );
     }
 }

--- a/src/test/java/com/zerocracy/pmo/ResumesTest.java
+++ b/src/test/java/com/zerocracy/pmo/ResumesTest.java
@@ -26,7 +26,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Month;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
@@ -125,7 +125,7 @@ public final class ResumesTest {
         final Resumes resumes = new Resumes(farm).bootstrap();
         resumes.add(
             login,
-            LocalDateTime.ofInstant(time, ZoneId.of("UTC")),
+            LocalDateTime.ofInstant(time, ZoneOffset.UTC),
             text,
             personality,
             id,

--- a/src/test/java/com/zerocracy/pmo/ResumesTest.java
+++ b/src/test/java/com/zerocracy/pmo/ResumesTest.java
@@ -21,10 +21,12 @@ import com.zerocracy.Farm;
 import com.zerocracy.Item;
 import com.zerocracy.Xocument;
 import com.zerocracy.farm.fake.FkFarm;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Month;
+import java.time.ZoneId;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
@@ -107,10 +109,7 @@ public final class ResumesTest {
     public void findResume() throws Exception {
         final Farm farm = new FkFarm();
         final String login = "login";
-        final LocalDateTime time = LocalDateTime.of(
-            LocalDate.of(2018, Month.JANUARY, 1),
-            LocalTime.of(0, 0)
-        );
+        final Instant time = Instant.parse("2018-01-01T00:00:00Z");
         final String text = "Resume text";
         final String personality = "ENTP-T";
         final int id = 187141;
@@ -126,7 +125,7 @@ public final class ResumesTest {
         final Resumes resumes = new Resumes(farm).bootstrap();
         resumes.add(
             login,
-            time,
+            LocalDateTime.ofInstant(time, ZoneId.of("UTC")),
             text,
             personality,
             id,


### PR DESCRIPTION
For #1569: Resumes.resume(login) implementation.
- Added `Resume` interface modeling a resume, with `Fake` implementation for tests
- Added `Resumes.resume(login)` method in resume
- Added test for `Resumes.resume(login)` in `ResumesTest`
- Left puzzle for `Resumes.resume(login)`