### PR TITLE
For #1333: Added board page fields to catalog.

### DIFF
--- a/src/test/java/com/zerocracy/pmo/CatalogTest.java
+++ b/src/test/java/com/zerocracy/pmo/CatalogTest.java
@@ -37,6 +37,7 @@ import org.cactoos.time.DateAsText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsEmptyIterable;
+import org.hamcrest.core.IsCollectionContaining;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
 import org.junit.Ignore;
@@ -224,14 +225,16 @@ public final class CatalogTest {
         );
         try (final Item item = CatalogTest.item(project)) {
             MatcherAssert.assertThat(
-                "Architect not found",
+                "Architect(s) not found",
                 new Xocument(item.path()).xpath(
                     new FormattedText(
                         "/catalog/project[@id='%s']/architect",
                         project.pid()
                     ).asString()
                 ),
-                new IsEqual<>(arc)
+                new IsCollectionContaining<>(
+                    new IsEqual<String>(arc)
+                )
             );
             MatcherAssert.assertThat(
                 "Members not found",
@@ -241,7 +244,9 @@ public final class CatalogTest {
                         project.pid()
                     ).asString()
                 ),
-                new IsEqual<>(dev)
+                new IsCollectionContaining<>(
+                    new IsEqual<String>(dev)
+                )
             );
             MatcherAssert.assertThat(
                 "Jobs not found",

--- a/src/test/java/com/zerocracy/pmo/CatalogTest.java
+++ b/src/test/java/com/zerocracy/pmo/CatalogTest.java
@@ -53,7 +53,8 @@ import org.xembly.Directives;
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle ExecutableStatementCountCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals",
+    "PMD.AvoidInstantiatingObjectsInLoops"})
 public final class CatalogTest {
 
     @Test
@@ -209,16 +210,13 @@ public final class CatalogTest {
             repo.issues().create("Job number one", "")
         ).toString();
         wbs.add(one);
-        wbs.add(
-            new Job(
-                repo.issues().create("Job number two", "")
-            ).toString()
-        );
-        wbs.add(
-            new Job(
-                repo.issues().create("Job number three", "")
-            ).toString()
-        );
+        for (int cont = 0; cont < Tv.THREE; cont = cont + 1) {
+            wbs.add(
+                new Job(
+                    repo.issues().create("Job", "")
+                ).toString()
+            );
+        }
         new Orders(project).bootstrap().assign(
             one,
             dev,
@@ -268,7 +266,7 @@ public final class CatalogTest {
                 new IsEqual<>(1)
             );
             MatcherAssert.assertThat(
-                "Assigned jobs not found",
+                "Total jobs not found",
                 new Xocument(item.path()).xpath(
                     new FormattedText(
                         "/catalog/project[@id='%s']/jobs[@total]",

--- a/src/test/java/com/zerocracy/pmo/CatalogTest.java
+++ b/src/test/java/com/zerocracy/pmo/CatalogTest.java
@@ -22,11 +22,13 @@ import com.jcabi.github.Repo;
 import com.jcabi.github.Repos;
 import com.jcabi.github.mock.MkGithub;
 import com.zerocracy.Item;
+import com.zerocracy.Par;
 import com.zerocracy.Project;
 import com.zerocracy.Xocument;
 import com.zerocracy.cash.Cash;
 import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.fake.FkProject;
+import com.zerocracy.pm.cost.Ledger;
 import com.zerocracy.pm.in.Orders;
 import com.zerocracy.pm.scope.Wbs;
 import com.zerocracy.pm.staff.Roles;
@@ -196,6 +198,14 @@ public final class CatalogTest {
     @Ignore
     public void catalogHasBoardPageInfo() throws Exception {
         final FkProject project = new FkProject();
+        new Ledger(project).bootstrap().add(
+            new Ledger.Transaction(
+              new Cash.S("$100"),
+              "assets", "cash",
+              "income", "zerocracy",
+              "Project funds"
+            )
+        );
         new Catalog(new FkFarm(project)).bootstrap();
         final Github github = new MkGithub();
         final Repo repo = github.repos().create(
@@ -279,6 +289,16 @@ public final class CatalogTest {
                     ).asString()
                 ),
                 new IsEqual<>(Tv.THREE)
+            );
+            MatcherAssert.assertThat(
+                "Funding info incorrect",
+                new Xocument(item.path()).xpath(
+                    new FormattedText(
+                        "/catalog/project[@id='%s']/funding[@amount]",
+                        project.pid()
+                    ).asString()
+                ),
+                new IsEqual<>(100)
             );
         }
     }

--- a/src/test/java/com/zerocracy/pmo/CatalogTest.java
+++ b/src/test/java/com/zerocracy/pmo/CatalogTest.java
@@ -16,24 +16,42 @@
  */
 package com.zerocracy.pmo;
 
+import com.jcabi.aspects.Tv;
+import com.jcabi.github.Github;
+import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
+import com.jcabi.github.mock.MkGithub;
 import com.zerocracy.Item;
 import com.zerocracy.Project;
 import com.zerocracy.Xocument;
 import com.zerocracy.cash.Cash;
 import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.fake.FkProject;
+import com.zerocracy.pm.in.Orders;
+import com.zerocracy.pm.scope.Wbs;
+import com.zerocracy.pm.staff.Roles;
+import com.zerocracy.radars.github.Job;
 import java.io.IOException;
+import org.cactoos.text.FormattedText;
 import org.cactoos.time.DateAsText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.collection.IsEmptyIterable;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.xembly.Directives;
 
 /**
  * Test case for {@link Catalog}.
  * @since 1.0
+ * @todo #1333:30min Board page is slow, load all project properties present in
+ *  board page in catalog.xml similar it is made in team page. After this,
+ *  uncomment test catalogHasBoardPageInfo
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @checkstyle ExecutableStatementCountCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class CatalogTest {
@@ -170,6 +188,96 @@ public final class CatalogTest {
             catalog.adviser(pid),
             Matchers.equalTo(adviser)
         );
+    }
+
+    @Test
+    @Ignore
+    public void catalogHasBoardPageInfo() throws Exception {
+        final FkProject project = new FkProject();
+        new Catalog(new FkFarm(project)).bootstrap();
+        final Github github = new MkGithub();
+        final Repo repo = github.repos().create(
+            new Repos.RepoCreate("test", false)
+        );
+        final String arc = "yegor256";
+        final String dev = "paulodamaso";
+        final Roles roles = new Roles(project).bootstrap();
+        roles.assign(arc, "ARC");
+        roles.assign(dev, "DEV");
+        final Wbs wbs = new Wbs(project).bootstrap();
+        final String one = new Job(
+            repo.issues().create("Job number one", "")
+        ).toString();
+        wbs.add(one);
+        wbs.add(
+            new Job(
+                repo.issues().create("Job number two", "")
+            ).toString()
+        );
+        wbs.add(
+            new Job(
+                repo.issues().create("Job number three", "")
+            ).toString()
+        );
+        new Orders(project).bootstrap().assign(
+            one,
+            dev,
+            Tv.TEN
+        );
+        try (final Item item = CatalogTest.item(project)) {
+            MatcherAssert.assertThat(
+                "Architect not found",
+                new Xocument(item.path()).xpath(
+                    new FormattedText(
+                        "/catalog/project[@id='%s']/architect",
+                        project.pid()
+                    ).asString()
+                ),
+                new IsEqual<>(arc)
+            );
+            MatcherAssert.assertThat(
+                "Members not found",
+                new Xocument(item.path()).xpath(
+                    new FormattedText(
+                        "/catalog/project[@id='%s']/members",
+                        project.pid()
+                    ).asString()
+                ),
+                new IsEqual<>(dev)
+            );
+            MatcherAssert.assertThat(
+                "Jobs not found",
+                new Xocument(item.path()).xpath(
+                    new FormattedText(
+                        "/catalog/project[@id='%s']/jobs",
+                        project.pid()
+                    ).asString()
+                ),
+                new IsNot<>(
+                    new IsEmptyIterable<>()
+                )
+            );
+            MatcherAssert.assertThat(
+                "Assigned jobs not found",
+                new Xocument(item.path()).xpath(
+                    new FormattedText(
+                        "/catalog/project[@id='%s']/jobs[@assigned]",
+                        project.pid()
+                    ).asString()
+                ),
+                new IsEqual<>(1)
+            );
+            MatcherAssert.assertThat(
+                "Assigned jobs not found",
+                new Xocument(item.path()).xpath(
+                    new FormattedText(
+                        "/catalog/project[@id='%s']/jobs[@total]",
+                        project.pid()
+                    ).asString()
+                ),
+                new IsEqual<>(Tv.THREE)
+            );
+        }
     }
 
     private static Item item(final Project project) throws IOException {

--- a/src/test/java/com/zerocracy/pmo/CatalogTest.java
+++ b/src/test/java/com/zerocracy/pmo/CatalogTest.java
@@ -22,7 +22,6 @@ import com.jcabi.github.Repo;
 import com.jcabi.github.Repos;
 import com.jcabi.github.mock.MkGithub;
 import com.zerocracy.Item;
-import com.zerocracy.Par;
 import com.zerocracy.Project;
 import com.zerocracy.Xocument;
 import com.zerocracy.cash.Cash;
@@ -200,10 +199,10 @@ public final class CatalogTest {
         final FkProject project = new FkProject();
         new Ledger(project).bootstrap().add(
             new Ledger.Transaction(
-              new Cash.S("$100"),
-              "assets", "cash",
-              "income", "zerocracy",
-              "Project funds"
+                new Cash.S("$100"),
+                "assets", "cash",
+                "income", "zerocracy",
+                "Current project funds"
             )
         );
         new Catalog(new FkFarm(project)).bootstrap();
@@ -222,17 +221,9 @@ public final class CatalogTest {
         ).toString();
         wbs.add(one);
         for (int cont = 0; cont < Tv.THREE; cont = cont + 1) {
-            wbs.add(
-                new Job(
-                    repo.issues().create("Job", "")
-                ).toString()
-            );
+            wbs.add(new Job(repo.issues().create("Job", "")).toString());
         }
-        new Orders(project).bootstrap().assign(
-            one,
-            dev,
-            Tv.TEN
-        );
+        new Orders(project).bootstrap().assign(one, dev, Tv.TEN);
         try (final Item item = CatalogTest.item(project)) {
             MatcherAssert.assertThat(
                 "Architect(s) not found",
@@ -242,9 +233,7 @@ public final class CatalogTest {
                         project.pid()
                     ).asString()
                 ),
-                new IsCollectionContaining<>(
-                    new IsEqual<String>(arc)
-                )
+                new IsCollectionContaining<>(new IsEqual<>(arc))
             );
             MatcherAssert.assertThat(
                 "Members not found",
@@ -254,9 +243,7 @@ public final class CatalogTest {
                         project.pid()
                     ).asString()
                 ),
-                new IsCollectionContaining<>(
-                    new IsEqual<String>(dev)
-                )
+                new IsCollectionContaining<>(new IsEqual<>(dev))
             );
             MatcherAssert.assertThat(
                 "Jobs not found",
@@ -266,9 +253,7 @@ public final class CatalogTest {
                         project.pid()
                     ).asString()
                 ),
-                new IsNot<>(
-                    new IsEmptyIterable<>()
-                )
+                new IsNot<>(new IsEmptyIterable<>())
             );
             MatcherAssert.assertThat(
                 "Assigned jobs not found",
@@ -298,7 +283,7 @@ public final class CatalogTest {
                         project.pid()
                     ).asString()
                 ),
-                new IsEqual<>(100)
+                new IsEqual<>("$100")
             );
         }
     }


### PR DESCRIPTION
For #1333: Added board fields to projects on catalog.:
- Added `catalogHasBoardPageInfo` to `CatalogTest` to test if information shown in board page is being stored in `catalog.xml`;
- Added puzzle to finish implementation of `Catalog`, which saves board pages information to `catalog.xml`