### PR TITLE
For #1536: Implement adviser payment on project funding.

### DIFF
--- a/src/test/resources/com/zerocracy/bundles/pays_adviser_on_funding/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/pays_adviser_on_funding/_after.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.pays_adviser_on_funding
+
+import com.jcabi.xml.XML
+import com.zerocracy.Project
+
+def exec(Project project, XML xml) {
+//  Farm farm = binding.variables.farm
+//  new Footprint(farm, project).withCloseable {
+//    Footprint footprint ->
+//    MatcherAssert.assertThat(
+//      'Adviser received wrong payment on stripe funding',
+//      footprint.collection().find(
+//        Filters.and(
+//          Filters.eq('project', project.pid()),
+//          Filters.eq('type', 'Make payment'),
+//          Filters.eq('login', 'yegor256'),
+//          Filters.eq('amount', '$4')
+//        )
+//      ),
+//      new IsIterableWithSize<>(
+//        new IsEqual<Integer>(1)
+//      )
+//    )
+//    MatcherAssert.assertThat(
+//      'Project received wrong funding on stripe funding',
+//      footprint.collection().find(
+//        Filters.and(
+//          Filters.eq('project', project.pid()),
+//          Filters.eq('type', 'Notify project'),
+//          Filters.eq('project', project.pid()),
+//          Filters.eq('amount', '$96')
+//        )
+//      ),
+//      new IsIterableWithSize<>(
+//        new IsEqual<Integer>(1)
+//      )
+//    )
+//    MatcherAssert.assertThat(
+//      'Adviser received wrong payment on donation',
+//      footprint.collection().find(
+//        Filters.and(
+//          Filters.eq('project', project.pid()),
+//          Filters.eq('type', 'Make payment'),
+//          Filters.eq('login', 'yegor256'),
+//          Filters.eq('amount', '$8')
+//        )
+//      ),
+//      new IsIterableWithSize<>(
+//        new IsEqual<Integer>(1)
+//      )
+//    )
+//    MatcherAssert.assertThat(
+//      'Project received wrong on donation',
+//      footprint.collection().find(
+//        Filters.and(
+//          Filters.eq('project', project.pid()),
+//          Filters.eq('type', 'Notify project'),
+//          Filters.eq('project', project.pid()),
+//          Filters.eq('amount', '$192')
+//        )
+//      ),
+//      new IsIterableWithSize<>(
+//        new IsEqual<Integer>(1)
+//      )
+//    )
+//  }
+}

--- a/src/test/resources/com/zerocracy/bundles/pays_adviser_on_funding/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/pays_adviser_on_funding/_after.groovy
@@ -19,6 +19,10 @@ package com.zerocracy.bundles.pays_adviser_on_funding
 import com.jcabi.xml.XML
 import com.zerocracy.Project
 
+// @todo #1536:30min Project is not paying adviser when being funded. Correct
+//  fund_by_stripe.groovy and donate.groovy to send a payment of 4% of the
+//  amount of funding to the project advisor on every funding operation. Then
+//  uncomment these tests to make sure that these payments are happening.'
 def exec(Project project, XML xml) {
 //  Farm farm = binding.variables.farm
 //  new Footprint(farm, project).withCloseable {

--- a/src/test/resources/com/zerocracy/bundles/pays_adviser_on_funding/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/pays_adviser_on_funding/_after.groovy
@@ -38,7 +38,7 @@ def exec(Project project, XML xml) {
 //        )
 //      ),
 //      new IsIterableWithSize<>(
-//        new IsEqual<Integer>(1)
+//        new IsEqual<>(1)
 //      )
 //    )
 //    MatcherAssert.assertThat(
@@ -52,7 +52,7 @@ def exec(Project project, XML xml) {
 //        )
 //      ),
 //      new IsIterableWithSize<>(
-//        new IsEqual<Integer>(1)
+//        new IsEqual<>(1)
 //      )
 //    )
 //    MatcherAssert.assertThat(
@@ -66,7 +66,7 @@ def exec(Project project, XML xml) {
 //        )
 //      ),
 //      new IsIterableWithSize<>(
-//        new IsEqual<Integer>(1)
+//        new IsEqual<>(1)
 //      )
 //    )
 //    MatcherAssert.assertThat(
@@ -80,7 +80,7 @@ def exec(Project project, XML xml) {
 //        )
 //      ),
 //      new IsIterableWithSize<>(
-//        new IsEqual<Integer>(1)
+//        new IsEqual<>(1)
 //      )
 //    )
 //  }

--- a/src/test/resources/com/zerocracy/bundles/pays_adviser_on_funding/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/pays_adviser_on_funding/_before.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.pays_adviser_on_funding
+
+import com.jcabi.xml.XML
+import com.zerocracy.Project
+
+def exec(Project project, XML xml) {
+
+}

--- a/src/test/resources/com/zerocracy/bundles/pays_adviser_on_funding/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/pays_adviser_on_funding/claims.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.2/xsd/pm/claims.xsd" version="0.1" updated="2017-03-27T11:18:09.228Z">
+  <claim id="1">
+    <type>Funded by Stripe</type>
+    <author>yegor256</author>
+    <created>2017-01-15T01:00:00.000Z</created>
+    <params>
+      <param name="amount">$100</param>
+      <param name="payment_id">SX987KUU31</param>
+      <param name="stripe_customer">SX987KUU31</param>
+    </params>
+  </claim>
+  <claim id="2">
+    <type>Donate</type>
+    <author>yegor256</author>
+    <params>
+      <param name="amount">$200</param>
+    </params>
+    <created>2017-01-15T01:00:00.000Z</created>
+  </claim>
+</claims>
+

--- a/src/test/resources/com/zerocracy/bundles/pays_adviser_on_funding/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/pays_adviser_on_funding/claims.xml
@@ -18,7 +18,7 @@ SOFTWARE.
 <claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.2/xsd/pm/claims.xsd" version="0.1" updated="2017-03-27T11:18:09.228Z">
   <claim id="1">
     <type>Funded by Stripe</type>
-    <author>yegor256</author>
+    <author>paulodamaso</author>
     <created>2017-01-15T01:00:00.000Z</created>
     <params>
       <param name="amount">$100</param>
@@ -28,11 +28,10 @@ SOFTWARE.
   </claim>
   <claim id="2">
     <type>Donate</type>
-    <author>yegor256</author>
+    <author>paulodamaso</author>
     <params>
       <param name="amount">$200</param>
     </params>
     <created>2017-01-15T01:00:00.000Z</created>
   </claim>
 </claims>
-


### PR DESCRIPTION
For #1536: Implement adviser payment on project funding.
- Added tests for:
  - checking if advisor received correct payment on project funding by stripe
  - checking if project received correct payment on project funding by stripe
  - checking if advisor received correct payment on project funding by donation
  - checking if project received correct payment on project funding by donation
