### PR TITLE
For #1649: Resume denial.

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pmo/resumes/assign_examiner.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pmo/resumes/assign_examiner.groovy
@@ -38,7 +38,10 @@ import org.cactoos.list.Shuffled
  *
  * @todo #1552:30min Allow examiner to reject resume by saying `deny @username`.
  *  In that case examiner should still get +32 points of reputation (and be
- *  notified about that).
+ *  notified about that). Implement deny @username stakeholder and create claim
+ *  Deny resume which must accept parameters set in
+ *  deny_resume_application\claims.xml. Then uncomment
+ *  deny_resume_application\_after.groovy tests.
  */
 def exec(Project project, XML xml) {
   new Assume(project, xml).isPmo()

--- a/src/test/resources/com/zerocracy/bundles/deny_resume_application/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/deny_resume_application/_after.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.deny_resume_application
+
+import com.jcabi.xml.XML
+import com.zerocracy.Project
+
+def exec(Project project, XML xml) {
+//  Farm farm = binding.variables.farm
+//  People people = new People(farm).bootstrap()
+//  String friend = 'friend'
+//  MatcherAssert.assertThat(
+//    people.hasMentor(friend),
+//    new IsEqual<>(false)
+//  )
+//  MatcherAssert.assertThat(
+//    new Awards(farm, 'user').bootstrap().total(),
+//    new IsEqual<>(1032)
+//  )
+//  project.acq('test.txt').withCloseable {
+//    item -> MatcherAssert.assertThat(
+//      item.path().text,
+//      new StringContains(
+//        new Par('You received bonus %d points for @%s resume examination').say(32, friend)
+//      )
+//    )
+//  }
+}

--- a/src/test/resources/com/zerocracy/bundles/deny_resume_application/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/deny_resume_application/_after.groovy
@@ -21,10 +21,9 @@ import com.zerocracy.Project
 
 def exec(Project project, XML xml) {
 //  Farm farm = binding.variables.farm
-//  People people = new People(farm).bootstrap()
 //  String friend = 'friend'
 //  MatcherAssert.assertThat(
-//    people.hasMentor(friend),
+//    new People(farm).bootstrap().hasMentor(friend),
 //    new IsEqual<>(false)
 //  )
 //  MatcherAssert.assertThat(

--- a/src/test/resources/com/zerocracy/bundles/deny_resume_application/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/deny_resume_application/_before.groovy
@@ -29,8 +29,9 @@ import java.time.LocalDateTime
 def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
   Resumes resumes = new Resumes(farm).bootstrap()
+  String login = 'friend'
   resumes.add(
-    'friend',
+    login,
     LocalDateTime.now(),
     'User description on himself',
     'INTP-A',
@@ -38,7 +39,7 @@ def exec(Project project, XML xml) {
     'telegramFriend'
   )
   String user = 'user'
-  resumes.assign('friend', user)
+  resumes.assign(login, user)
   new ExtGithub(farm).value().repos().create(new Repos.RepoCreate('test', false))
   new Awards(farm, user).bootstrap().add(
     project, 1000, 'gh:test/test#1', 'test'

--- a/src/test/resources/com/zerocracy/bundles/deny_resume_application/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/deny_resume_application/_before.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.deny_resume_application
+
+import com.jcabi.github.Repos
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.entry.ExtGithub
+import com.zerocracy.pmo.Awards
+import com.zerocracy.pmo.Resumes
+
+import java.time.LocalDateTime
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  Resumes resumes = new Resumes(farm).bootstrap()
+  resumes.add(
+    'friend',
+    LocalDateTime.now(),
+    'User description on himself',
+    'INTP-A',
+    1000541,
+    'telegramFriend'
+  )
+  String user = 'user'
+  resumes.assign('friend', user)
+  new ExtGithub(farm).value().repos().create(new Repos.RepoCreate('test', false))
+  new Awards(farm, user).bootstrap().add(
+    project, 1000, 'gh:test/test#1', 'test'
+  )
+}

--- a/src/test/resources/com/zerocracy/bundles/deny_resume_application/_setup.xml
+++ b/src/test/resources/com/zerocracy/bundles/deny_resume_application/_setup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<setup>
+  <pmo>true</pmo>
+</setup>

--- a/src/test/resources/com/zerocracy/bundles/deny_resume_application/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/deny_resume_application/claims.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.37/xsd/pm/claims.xsd" version="0.1" updated="2017-03-27T11:18:09.228Z">
+  <claim id="100">
+    <type>Deny resume</type>
+    <token>test;C123;test</token>
+    <author>user</author>
+    <params>
+      <param name="login">friend</param>
+    </params>
+    <created>2018-07-15T01:00:00.000Z</created>
+  </claim>
+</claims>

--- a/src/test/resources/com/zerocracy/bundles/deny_resume_application/people.xml
+++ b/src/test/resources/com/zerocracy/bundles/deny_resume_application/people.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<people xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.37/xsd/pmo/people.xsd" version="1" updated="2016-12-29T09:03:21.684Z">
+  <person id="user">
+    <mentor>0crat</mentor>
+  </person>
+</people>


### PR DESCRIPTION
For #1649:
- Added tests for checking if examiner received points for user resume denial, if examiner is not responsible for user resume anymore and if examiner received message.