### PR TITLE
#1635 ARC bonus on specific claims only, added "Job was declined" claim

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pm/cost/pay_architect_for_release.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/cost/pay_architect_for_release.groovy
@@ -22,13 +22,12 @@ import com.zerocracy.Farm
 import com.zerocracy.Par
 import com.zerocracy.Policy
 import com.zerocracy.Project
-import com.zerocracy.entry.ClaimsOf
-import com.zerocracy.farm.Assume
 import com.zerocracy.claims.ClaimIn
 import com.zerocracy.claims.Footprint
+import com.zerocracy.entry.ClaimsOf
+import com.zerocracy.farm.Assume
 import com.zerocracy.pm.staff.Roles
 import com.zerocracy.pm.time.Releases
-
 import java.time.Duration
 import java.time.Instant
 
@@ -56,10 +55,19 @@ def exec(Project project, XML xml) {
     footprint.collection().countDocuments(
       Filters.and(
         Filters.gt('created', Date.from(latest)),
-        Filters.and(
-          Filters.not(Filters.regex('type', 'Ping.*')),
-          Filters.ne('type', 'Error'),
-          Filters.not(Filters.regex('type', 'Notify.*')),
+        Filters.or(
+          Filters.eq('type', 'Order was given'),
+          Filters.eq('type', 'Order was canceled'),
+          Filters.eq('type', 'Order was finished'),
+          Filters.eq('type', 'Request order start'),
+          Filters.eq('type', 'Job removed from WBS'),
+          Filters.eq('type', 'Job was added to WBS'),
+          Filters.eq('type', 'Quality review completed'),
+          Filters.eq('type', 'Register impediment'),
+          Filters.eq('type', 'Set boost'),
+          Filters.eq('type', 'Assign role'),
+          Filters.eq('type', 'Resign role'),
+          Filters.eq('type', 'Job was declined'),
         ),
       )
     )

--- a/src/main/groovy/com/zerocracy/stk/pm/in/orders/close_job.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/in/orders/close_job.groovy
@@ -23,10 +23,10 @@ import com.zerocracy.Farm
 import com.zerocracy.Par
 import com.zerocracy.Project
 import com.zerocracy.SoftException
+import com.zerocracy.claims.ClaimIn
 import com.zerocracy.entry.ClaimsOf
 import com.zerocracy.entry.ExtGithub
 import com.zerocracy.farm.Assume
-import com.zerocracy.claims.ClaimIn
 import com.zerocracy.pm.in.Orders
 import com.zerocracy.pm.scope.Wbs
 import com.zerocracy.pm.staff.Roles
@@ -45,9 +45,11 @@ def exec(Project project, XML xml) {
   String author = issue.author().login().toLowerCase(Locale.ENGLISH)
   if (!wbs.exists(job)) {
     new Blanks(farm, author).bootstrap().add(project, job, issue.pull ? 'pull-request' : 'issue')
-    throw new SoftException(
-      new Par('The job is not in WBS, won\'t close the order').say()
-    )
+    claim.copy()
+      .type('Job was declined')
+      .token("job;${job}")
+      .param('message', message)
+      .postTo(new ClaimsOf(farm, project))
   }
   Orders orders = new Orders(project).bootstrap()
   if (job.startsWith('gh:') && orders.assigned(job)) {

--- a/src/main/groovy/com/zerocracy/stk/pm/in/orders/close_job.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/in/orders/close_job.groovy
@@ -48,7 +48,6 @@ def exec(Project project, XML xml) {
     claim.copy()
       .type('Job was declined')
       .token("job;${job}")
-      .param('message', message)
       .postTo(new ClaimsOf(farm, project))
   }
   Orders orders = new Orders(project).bootstrap()

--- a/src/main/groovy/com/zerocracy/stk/pm/in/orders/notify_declined_job.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/in/orders/notify_declined_job.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.stk.pm.in.orders
+
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Par
+import com.zerocracy.Project
+import com.zerocracy.claims.ClaimIn
+import com.zerocracy.entry.ClaimsOf
+import com.zerocracy.farm.Assume
+
+def exec(Project project, XML xml) {
+  new Assume(project, xml).notPmo()
+  new Assume(project, xml).type('Job was declined')
+  ClaimIn claim = new ClaimIn(xml)
+  Farm farm = binding.variables.farm
+  claim.copy()
+    .type('Notify job')
+    .param(
+    'message',
+    new Par(
+      farm,
+      'This job is not in scope, closed by @%s'
+    ).say(claim.author())
+  )
+    .postTo(new ClaimsOf(farm, project))
+}

--- a/src/main/groovy/com/zerocracy/stk/pm/in/orders/notify_declined_job.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/in/orders/notify_declined_job.groovy
@@ -32,11 +32,10 @@ def exec(Project project, XML xml) {
   claim.copy()
     .type('Notify job')
     .param(
-    'message',
-    new Par(
-      farm,
-      'This job is not in scope, closed by @%s'
-    ).say(claim.author())
-  )
-    .postTo(new ClaimsOf(farm, project))
+      'message',
+      new Par(
+        farm,
+        'This job is not in scope, closed by @%s'
+      ).say(claim.author())
+    ).postTo(new ClaimsOf(farm, project))
 }

--- a/src/test/resources/com/zerocracy/bundles/notifies_declined_job/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/notifies_declined_job/_after.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.notifies_declined_job
+
+import com.jcabi.github.Comment
+import com.jcabi.github.Coordinates
+import com.jcabi.github.Github
+import com.jcabi.github.Issue
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.entry.ExtGithub
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  Github github = new ExtGithub(farm).value()
+  Issue issue = github.repos()
+    .get(new Coordinates.Simple('test/test'))
+    .issues()
+    .get(1)
+  String comment = new Comment.Smart(issue.comments().get(1)).body()
+  MatcherAssert.assertThat(
+    comment,
+    Matchers.startsWith('This job is not in scope, closed by @yegor256')
+  )
+}

--- a/src/test/resources/com/zerocracy/bundles/notifies_declined_job/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/notifies_declined_job/_before.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.notifies_declined_job
+
+import com.jcabi.github.Github
+import com.jcabi.github.Repos
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.entry.ExtGithub
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  Github github = new ExtGithub(farm).value()
+  github.repos().create(new Repos.RepoCreate('test', false))
+    .issues()
+    .create('hello, world', '')
+}

--- a/src/test/resources/com/zerocracy/bundles/notifies_declined_job/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/notifies_declined_job/_before.groovy
@@ -16,7 +16,6 @@
  */
 package com.zerocracy.bundles.notifies_declined_job
 
-import com.jcabi.github.Github
 import com.jcabi.github.Repos
 import com.jcabi.xml.XML
 import com.zerocracy.Farm
@@ -25,8 +24,8 @@ import com.zerocracy.entry.ExtGithub
 
 def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
-  Github github = new ExtGithub(farm).value()
-  github.repos().create(new Repos.RepoCreate('test', false))
+  new ExtGithub(farm).value().repos()
+    .create(new Repos.RepoCreate('test', false))
     .issues()
     .create('hello, world', '')
 }

--- a/src/test/resources/com/zerocracy/bundles/notifies_declined_job/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/notifies_declined_job/claims.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.2/xsd/pm/claims.xsd" updated="2017-07-21T20:31:44.512Z" version="1">
+  <claim id="1">
+    <created>2017-07-21T20:32:19.716Z</created>
+    <type>Job was declined</type>
+    <token>job;gh:test/test#1</token>
+    <author>yegor256</author>
+  </claim>
+</claims>

--- a/src/test/resources/com/zerocracy/bundles/notifies_declined_job/people.xml
+++ b/src/test/resources/com/zerocracy/bundles/notifies_declined_job/people.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<people xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.28/xsd/pmo/people.xsd" version="1" updated="2016-12-29T09:03:21.684Z">
+  <person id="yegor256">
+    <mentor>0crat</mentor>
+  </person>
+</people>


### PR DESCRIPTION
#1635: Changed `pay_architect_for_release.groovy` to get specific claims instead of only excluding pings, notifys, and errors.

Also added `Job was declined` claim, and added a new stakeholder for that claim to handle notifications (which was previously handled by throwing `SoftException`).