### PR TITLE
For #1644: MongoDB lock implementation.

### DIFF
--- a/src/main/java/com/zerocracy/farm/sync/MongoDbLock.java
+++ b/src/main/java/com/zerocracy/farm/sync/MongoDbLock.java
@@ -82,10 +82,10 @@ public final class MongoDbLock implements Lock {
     }
 
     // @todo #1644:30min Implement external locking mechanism based in MongoDB.
-    // According to javas Lock interface, when there is already a lock on given
-    // resource, it should suspend the thread until it is possible to do a lock.
-    // This class is not implementing this behavior on lock() method. Implement
-    // this so this lock should block until the resource is unlocked.
+    //  According to javas Lock interface, when there is already a lock on given
+    //  resource, it should suspend the thread until it is possible to do a
+    //  lock. This class is not implementing this behavior on lock() method.
+    //  Implement this so this lock should block until the resource is unlocked.
     @Override
     public void lock() {
         final Document lock = new Document();

--- a/src/main/java/com/zerocracy/farm/sync/MongoDbLock.java
+++ b/src/main/java/com/zerocracy/farm/sync/MongoDbLock.java
@@ -21,7 +21,7 @@ import com.mongodb.client.model.Filters;
 import com.zerocracy.Farm;
 import com.zerocracy.entry.ExtMongo;
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import org.bson.Document;
@@ -36,22 +36,22 @@ public final class MongoDbLock implements Lock {
     /**
      * Mongo database name.
      */
-    public static final String DATABASE = "locksdb";
+    private static final String DATABASE = "locksdb";
 
     /**
      * Mongo lock collection name.
      */
-    public static final String COLLECTION = "locks";
+    private static final String COLLECTION = "locks";
 
     /**
      * Resource field name.
      */
-    public static final String RESOURCE = "resource";
+    private static final String RESOURCE = "resource";
 
     /**
      * Time field name.
      */
-    public static final String TIME = "time";
+    private static final String TIME = "time";
 
     /**
      * MongoDB client.
@@ -85,7 +85,7 @@ public final class MongoDbLock implements Lock {
     public void lock() {
         final Document lock = new Document();
         lock.put(MongoDbLock.RESOURCE, this.resource);
-        lock.put(MongoDbLock.TIME, new Date());
+        lock.put(MongoDbLock.TIME, Instant.now());
         this.client.getDatabase(
             MongoDbLock.DATABASE
         ).getCollection(MongoDbLock.COLLECTION).insertOne(lock);

--- a/src/main/java/com/zerocracy/farm/sync/MongoDbLock.java
+++ b/src/main/java/com/zerocracy/farm/sync/MongoDbLock.java
@@ -81,6 +81,11 @@ public final class MongoDbLock implements Lock {
         );
     }
 
+    // @todo #1644:30min Implement external locking mechanism based in MongoDB.
+    // According to javas Lock interface, when there is already a lock on given
+    // resource, it should suspend the thread until it is possible to do a lock.
+    // This class is not implementing this behavior on lock() method. Implement
+    // this so this lock should block until the resource is unlocked.
     @Override
     public void lock() {
         final Document lock = new Document();

--- a/src/main/java/com/zerocracy/farm/sync/MongoDbLock.java
+++ b/src/main/java/com/zerocracy/farm/sync/MongoDbLock.java
@@ -16,19 +16,63 @@
  */
 package com.zerocracy.farm.sync;
 
+import com.mongodb.MongoClient;
+import com.mongodb.client.model.Filters;
+import com.zerocracy.Farm;
+import com.zerocracy.entry.ExtMongo;
+import java.io.IOException;
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
+import org.bson.Document;
 
 /**
  * {@link Lock} using MongoDB.
  *
  * @since 1.0
- * @todo #1465:30min Implement external locking mechanism based in MongoDB.
- *  The lock must be set to some resource in a table where resource path and
- *  name must be set, along with time of lock. Then remove expects from
- *  MongoDBLockTest.
  */
 public final class MongoDbLock implements Lock {
+
+    /**
+     * Mongo database name.
+     */
+    public static final String DATABASE = "locksdb";
+
+    /**
+     * Mongo lock collection name.
+     */
+    public static final String COLLECTION = "locks";
+
+    /**
+     * Resource field name.
+     */
+    public static final String RESOURCE = "resource";
+
+    /**
+     * Time field name.
+     */
+    public static final String TIME = "time";
+
+    /**
+     * MongoDB client.
+     */
+    private final MongoClient client;
+
+    /**
+     * Resource to be locked.
+     */
+    private final String resource;
+
+    /**
+     * Constructor.
+     * @param farm Farm containing the resource
+     * @param resource Resource to be locked
+     * @throws IOException If something goes wrong
+     */
+    MongoDbLock(final Farm farm, final String resource) throws IOException {
+        this.client = new ExtMongo(farm).value();
+        this.resource = resource;
+    }
 
     @Override
     public StackTraceElement[] stacktrace() {
@@ -39,9 +83,12 @@ public final class MongoDbLock implements Lock {
 
     @Override
     public void lock() {
-        throw new UnsupportedOperationException(
-            "lock() is not implemented"
-        );
+        final Document lock = new Document();
+        lock.put(MongoDbLock.RESOURCE, this.resource);
+        lock.put(MongoDbLock.TIME, new Date());
+        this.client.getDatabase(
+            MongoDbLock.DATABASE
+        ).getCollection(MongoDbLock.COLLECTION).insertOne(lock);
     }
 
     @Override
@@ -53,9 +100,14 @@ public final class MongoDbLock implements Lock {
 
     @Override
     public boolean tryLock() {
-        throw new UnsupportedOperationException(
-            "tryLock() is not implemented"
-        );
+        final boolean lock;
+        if (this.locked()) {
+            lock = false;
+        } else {
+            this.lock();
+            lock = true;
+        }
+        return lock;
     }
 
     @Override
@@ -68,9 +120,11 @@ public final class MongoDbLock implements Lock {
 
     @Override
     public void unlock() {
-        throw new UnsupportedOperationException(
-            "unlock() is not implemented"
-        );
+        this.client.getDatabase(
+            MongoDbLock.DATABASE
+        ).getCollection(MongoDbLock.COLLECTION).deleteOne(
+            Filters.eq(MongoDbLock.RESOURCE, this.resource)
+            );
     }
 
     @Override
@@ -82,8 +136,24 @@ public final class MongoDbLock implements Lock {
 
     @Override
     public String toString() {
-        throw new UnsupportedOperationException(
-            "toString() is not implemented"
-        );
+        final String text;
+        if (this.locked()) {
+            text = "locked";
+        } else {
+            text = "free";
+        }
+        return text;
+    }
+
+    /**
+     * Is this lock locked?
+     * @return The lock locked status
+     */
+    private boolean locked() {
+        return this.client.getDatabase(
+            MongoDbLock.DATABASE
+        ).getCollection(MongoDbLock.COLLECTION).find(
+            Filters.eq(MongoDbLock.RESOURCE, this.resource)
+        ).iterator().hasNext();
     }
 }

--- a/src/test/java/com/zerocracy/farm/sync/MongoDbLockTest.java
+++ b/src/test/java/com/zerocracy/farm/sync/MongoDbLockTest.java
@@ -27,10 +27,13 @@ import org.junit.Test;
  * Test case for {@link MongoDbLock}.
  * @since 1.0
  * @todo #1644:30min Implement external locking mechanism based in MongoDB.
- *  Implement tests for methods in MongoDbLock. These methods must behave as
- *  specified in in java 8 java.util.concurrent.locks.Lock interface, except
- *  stacktrace() which must behave like SmartLock.stacktrace(). Then
- *  implement these methods so them pass all tests.
+ *  Implement tests for methods in MongoDbLock (stacktrace(), lock(),
+ *  lockInterruptibly(), tryLock(),
+ *  tryLock(final long time, final TimeUnit unit), unlock() and newCondition()).
+ *  These methods must behave as specified in in java 8
+ *  java.util.concurrent.locks.Lock interface, except stacktrace() which must
+ *  behave like SmartLock.stacktrace(). Then implement these methods so they'll
+ *  pass all the tests below.
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class MongoDbLockTest {

--- a/src/test/java/com/zerocracy/farm/sync/MongoDbLockTest.java
+++ b/src/test/java/com/zerocracy/farm/sync/MongoDbLockTest.java
@@ -16,6 +16,7 @@
  */
 package com.zerocracy.farm.sync;
 
+import com.zerocracy.farm.props.PropsFarm;
 import java.util.concurrent.locks.Lock;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsNot;
@@ -24,15 +25,19 @@ import org.junit.Test;
 
 /**
  * Test case for {@link MongoDbLock}.
- *
  * @since 1.0
+ * @todo #1644:30min Implement external locking mechanism based in MongoDB.
+ *  Implement tests for methods in MongoDbLock. These methods must behave as
+ *  specified in in java 8 java.util.concurrent.locks.Lock interface, except
+ *  stacktrace() which must behave like SmartLock.stacktrace(). Then
+ *  implement these methods so them pass all tests.
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class MongoDbLockTest {
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void buildsToStringWhenFresh() throws Exception {
-        final Lock lock = new MongoDbLock();
+        final Lock lock = new MongoDbLock(new PropsFarm(), "unlockedresource");
         MatcherAssert.assertThat(
             lock.toString(),
             new IsNot<>(
@@ -41,9 +46,9 @@ public final class MongoDbLockTest {
         );
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void buildsToStringWhenLocked() throws Exception {
-        final Lock lock = new MongoDbLock();
+        final Lock lock = new MongoDbLock(new PropsFarm(), "lockedresource");
         lock.lock();
         try {
             MatcherAssert.assertThat(
@@ -59,7 +64,7 @@ public final class MongoDbLockTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void buildsToStringWhenLockedInterruptibly() throws Exception {
-        final Lock lock = new MongoDbLock();
+        final Lock lock = new MongoDbLock(new PropsFarm(), "someresource");
         lock.lockInterruptibly();
         try {
             MatcherAssert.assertThat(


### PR DESCRIPTION
For #1644: MongoDB lock implementation.
- Implemented `tryLock()`, `lock()`, `unlock()` and `toString()` in `MongoDbLock`
- Uncommented tests referring these methods in `MongoDbLockTests`
- Left puzzle for creating more tests and complete implementation