### PR TITLE
#930 Display project languages on Board

### DIFF
--- a/src/main/java/com/zerocracy/tk/TkBoard.java
+++ b/src/main/java/com/zerocracy/tk/TkBoard.java
@@ -16,11 +16,15 @@
  */
 package com.zerocracy.tk;
 
+import com.jcabi.github.Coordinates;
+import com.jcabi.github.Github;
+import com.jcabi.github.Language;
 import com.jcabi.xml.XML;
 import com.zerocracy.Farm;
 import com.zerocracy.Item;
 import com.zerocracy.Project;
 import com.zerocracy.Xocument;
+import com.zerocracy.entry.ExtGithub;
 import com.zerocracy.pm.cost.Estimates;
 import com.zerocracy.pm.cost.Ledger;
 import com.zerocracy.pm.in.Orders;
@@ -30,9 +34,12 @@ import com.zerocracy.pmo.Catalog;
 import com.zerocracy.pmo.Pmo;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.Set;
 import org.cactoos.func.FuncOf;
 import org.cactoos.scalar.And;
+import org.cactoos.text.JoinedText;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
@@ -47,6 +54,7 @@ import org.takes.rs.xe.XeTransform;
  * @since 1.0
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings({"PMD.ExcessiveImports", "PMD.AvoidDuplicateLiterals"})
 public final class TkBoard implements Take {
 
     /**
@@ -55,11 +63,26 @@ public final class TkBoard implements Take {
     private final Farm farm;
 
     /**
+     * Github.
+     */
+    private final Github github;
+
+    /**
      * Ctor.
      * @param frm Farm
      */
     public TkBoard(final Farm frm) {
+        this(frm, new ExtGithub(frm).value());
+    }
+
+    /**
+     * Ctor.
+     * @param frm Farm
+     * @param github Github
+     */
+    TkBoard(final Farm frm, final Github github) {
         this.farm = frm;
+        this.github = github;
     }
 
     @Override
@@ -126,6 +149,9 @@ public final class TkBoard implements Take {
                 )
             ),
             new XeAppend(
+                "languages", this.languages(node)
+            ),
+            new XeAppend(
                 "jobs",
                 Integer.toString(new Wbs(project).bootstrap().iterate().size())
             ),
@@ -152,6 +178,28 @@ public final class TkBoard implements Take {
                 )
             )
         );
+    }
+
+    /**
+     * Get languages from repos.
+     * @param node XML
+     * @return Languages
+     * @throws IOException If an IO error occurs
+     * @todo #930:30min Right now we are displaying all languages for all
+     *  repositories. We should only display the top 4 languages (ranked by
+     *  bytes of code, as returned by Github) across all project repos.
+     */
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+    private String languages(final XML node) throws IOException {
+        final Set<String> langs = new HashSet<>();
+        for (final String repo
+            : node.xpath("links/link[@rel='github']/@href")) {
+            for (final Language lang : this.github.repos()
+                .get(new Coordinates.Simple(repo)).languages()) {
+                langs.add(lang.name());
+            }
+        }
+        return new JoinedText(",", langs).asString();
     }
 
 }

--- a/src/main/resources/xsl/board.xsl
+++ b/src/main/resources/xsl/board.xsl
@@ -71,6 +71,9 @@ SOFTWARE.
             <xsl:text>GitHub Repositories</xsl:text>
           </th>
           <th>
+            <xsl:text>Languages</xsl:text>
+          </th>
+          <th>
             <xsl:text>Members</xsl:text>
           </th>
           <th>
@@ -150,6 +153,9 @@ SOFTWARE.
       </td>
       <td>
         <xsl:apply-templates select="repositories"/>
+      </td>
+      <td>
+        <xsl:value-of select="languages"/>
       </td>
       <td style="text-align:right;">
         <xsl:if test="mine='false'">

--- a/src/test/java/com/zerocracy/tk/TkBoardTest.java
+++ b/src/test/java/com/zerocracy/tk/TkBoardTest.java
@@ -22,6 +22,7 @@ import com.jcabi.matchers.XhtmlMatchers;
 import com.zerocracy.Farm;
 import com.zerocracy.Project;
 import com.zerocracy.cash.Cash;
+import com.zerocracy.entry.ExtGithub;
 import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pm.cost.Ledger;
@@ -41,14 +42,15 @@ public final class TkBoardTest {
     @Test
     public void rendersBoardWithFundedProject() throws Exception {
         final Farm farm = new PropsFarm(new FkFarm());
-        final Repo repo = new MkGithub().randomRepo();
+        final Repo repo = ((MkGithub) new ExtGithub(farm).value())
+            .randomRepo();
         final Project project = farm.find("").iterator().next();
         final Catalog catalog = new Catalog(farm).bootstrap();
         catalog.add(project.pid(), "2017/01/AAAABBBBC/");
         catalog.link(
             project.pid(),
             "github",
-            repo.coordinates().repo()
+            repo.coordinates().toString()
         );
         catalog.publish(project.pid(), true);
         final Ledger ledger = new Ledger(project).bootstrap();
@@ -76,14 +78,15 @@ public final class TkBoardTest {
     @Test
     public void rendersBoardWithProjectWithoutFunding() throws Exception {
         final Farm farm = new PropsFarm(new FkFarm());
-        final Repo repo = new MkGithub().randomRepo();
+        final Repo repo = ((MkGithub) new ExtGithub(farm).value())
+            .randomRepo();
         final Project project = farm.find("").iterator().next();
         final Catalog catalog = new Catalog(farm).bootstrap();
         catalog.add(project.pid(), "2017/02/AAAABBBBC/");
         catalog.link(
             project.pid(),
             "github",
-            repo.coordinates().repo()
+            repo.coordinates().toString()
         );
         catalog.publish(project.pid(), true);
         MatcherAssert.assertThat(
@@ -98,14 +101,15 @@ public final class TkBoardTest {
     @Test
     public void doesNotShowProjectsNegativeBalance() throws Exception {
         final Farm farm = new PropsFarm(new FkFarm());
-        final Repo repo = new MkGithub().randomRepo();
+        final Repo repo = ((MkGithub) new ExtGithub(farm).value())
+            .randomRepo();
         final Project project = farm.find("").iterator().next();
         final Catalog catalog = new Catalog(farm).bootstrap();
         catalog.add(project.pid(), "2017/01/AAAABBBBC/");
         catalog.link(
             project.pid(),
             "github",
-            repo.coordinates().repo()
+            repo.coordinates().toString()
         );
         catalog.publish(project.pid(), true);
         final Ledger ledger = new Ledger(project).bootstrap();
@@ -131,6 +135,29 @@ public final class TkBoardTest {
             XhtmlMatchers.hasXPaths(
                 // @checkstyle LineLength (1 line)
                 "//xhtml:span[@title = 'The project is not properly funded' and . = 'no funds']"
+            )
+        );
+    }
+
+    @Test
+    public void displaysLanguages() throws Exception {
+        final Farm farm = new PropsFarm(new FkFarm());
+        final Repo repo = ((MkGithub) new ExtGithub(farm).value())
+            .randomRepo();
+        final Project project = farm.find("").iterator().next();
+        final Catalog catalog = new Catalog(farm).bootstrap();
+        catalog.add(project.pid(), "2017/02/AAAABBBBC/");
+        catalog.link(
+            project.pid(),
+            "github",
+            repo.coordinates().toString()
+        );
+        catalog.publish(project.pid(), true);
+        MatcherAssert.assertThat(
+            new View(farm, "/board").html(),
+            XhtmlMatchers.hasXPaths(
+                // @checkstyle LineLength (1 line)
+                "//xhtml:td[contains(text(), 'Java')]"
             )
         );
     }


### PR DESCRIPTION
#930: Get all languages from project repos and display them on the board.

Note to reviewer: that the `MkGithub` API returns dummy language values including Java. This is why the unit test works.

Left a puzzle to narrow down display to only the top four ranked languages.