### PR TITLE
#924 Resign users absent from people.xml

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pm/staff/remove_stale_users.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/staff/remove_stale_users.groovy
@@ -24,17 +24,12 @@ import com.zerocracy.claims.ClaimIn
 import com.zerocracy.entry.ClaimsOf
 import com.zerocracy.farm.Assume
 import com.zerocracy.pm.staff.Roles
-import com.zerocracy.pmo.Catalog
 import com.zerocracy.pmo.People
 
 def exec(Project project, XML xml) {
   new Assume(project, xml).notPmo()
   new Assume(project, xml).type('Ping hourly')
   Farm farm = binding.variables.farm
-  Catalog catalog = new Catalog(farm).bootstrap()
-  if (!catalog.sandbox().contains(project.pid())) {
-    return
-  }
   ClaimIn claim = new ClaimIn(xml)
   People people = new People(farm).bootstrap()
   Roles roles = new Roles(project).bootstrap()

--- a/src/main/groovy/com/zerocracy/stk/pm/staff/remove_stale_users.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/staff/remove_stale_users.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.stk.pm.staff
+
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Par
+import com.zerocracy.Project
+import com.zerocracy.claims.ClaimIn
+import com.zerocracy.entry.ClaimsOf
+import com.zerocracy.farm.Assume
+import com.zerocracy.pm.staff.Roles
+import com.zerocracy.pmo.Catalog
+import com.zerocracy.pmo.People
+
+def exec(Project project, XML xml) {
+  new Assume(project, xml).notPmo()
+  new Assume(project, xml).type('Ping hourly')
+  Farm farm = binding.variables.farm
+  Catalog catalog = new Catalog(farm).bootstrap()
+  if (!catalog.sandbox().contains(project.pid())) {
+    return
+  }
+  ClaimIn claim = new ClaimIn(xml)
+  People people = new People(farm).bootstrap()
+  Roles roles = new Roles(project).bootstrap()
+  roles.everybody().each { uid ->
+    if (people.exists(uid) || roles.hasRole(uid, 'PO')) {
+      return
+    }
+    claim.copy()
+      .type('Resign all roles')
+      .param('login', uid)
+      .param(
+        'reason',
+        new Par('@%s is no longer part of Zerocracy').say(uid)
+      ).postTo(new ClaimsOf(farm, project))
+  }
+}

--- a/src/test/resources/com/zerocracy/bundles/resigns_stale_users_from_project/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/resigns_stale_users_from_project/_after.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.resigns_stale_users_from_project
+
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.pm.staff.Roles
+import org.hamcrest.MatcherAssert
+import org.hamcrest.collection.IsEmptyCollection
+import org.hamcrest.core.IsCollectionContaining
+import org.hamcrest.core.IsEqual
+import org.hamcrest.core.IsNot
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  Roles roles = new Roles(project).bootstrap()
+  MatcherAssert.assertThat(
+      'g4s8 is resigned from project',
+      roles.allRoles('g4s8'),
+      new IsEmptyCollection<>()
+  )
+  MatcherAssert.assertThat(
+      'yegor256 is still PO',
+      roles.allRoles('yegor256'),
+      new IsCollectionContaining<>(
+          new IsEqual('PO')
+      )
+  )
+  MatcherAssert.assertThat(
+      'carlosmiranda is still DEV',
+      roles.allRoles('carlosmiranda'),
+      new IsNot<>(
+          new IsCollectionContaining<>(
+              new IsEqual('DEV')
+          )
+      )
+  )
+}

--- a/src/test/resources/com/zerocracy/bundles/resigns_stale_users_from_project/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/resigns_stale_users_from_project/_after.groovy
@@ -17,7 +17,6 @@
 package com.zerocracy.bundles.resigns_stale_users_from_project
 
 import com.jcabi.xml.XML
-import com.zerocracy.Farm
 import com.zerocracy.Project
 import com.zerocracy.pm.staff.Roles
 import org.hamcrest.MatcherAssert
@@ -27,22 +26,21 @@ import org.hamcrest.core.IsEqual
 import org.hamcrest.core.IsNot
 
 def exec(Project project, XML xml) {
-  Farm farm = binding.variables.farm
   Roles roles = new Roles(project).bootstrap()
   MatcherAssert.assertThat(
-      'g4s8 is resigned from project',
+      'g4s8 is not found but not resigned from project',
       roles.allRoles('g4s8'),
       new IsEmptyCollection<>()
   )
   MatcherAssert.assertThat(
-      'yegor256 is still PO',
+      'yegor256 was removed, even with role PO',
       roles.allRoles('yegor256'),
       new IsCollectionContaining<>(
           new IsEqual('PO')
       )
   )
   MatcherAssert.assertThat(
-      'carlosmiranda is still DEV',
+      'carlosmiranda is active and supposed to remain DEV',
       roles.allRoles('carlosmiranda'),
       new IsNot<>(
           new IsCollectionContaining<>(

--- a/src/test/resources/com/zerocracy/bundles/resigns_stale_users_from_project/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/resigns_stale_users_from_project/_before.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.resigns_stale_users_from_project
+
+import com.jcabi.xml.XML
+import com.zerocracy.Project
+
+def exec(Project project, XML xml) {
+  // Nothing to do.
+}

--- a/src/test/resources/com/zerocracy/bundles/resigns_stale_users_from_project/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/resigns_stale_users_from_project/claims.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pm/claims.xsd" version="0.1" updated="2017-08-18T13:18:00.000Z">
+  <claim id="1">
+    <type>Ping hourly</type>
+    <created>2017-01-15T01:00:00.000Z</created>
+  </claim>
+</claims>

--- a/src/test/resources/com/zerocracy/bundles/resigns_stale_users_from_project/people.xml
+++ b/src/test/resources/com/zerocracy/bundles/resigns_stale_users_from_project/people.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<people xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.61.2/xsd/pmo/people.xsd" version="1" updated="2016-12-29T09:03:21.684Z">
+  <person id="carlosmiranda">
+    <mentor>0crat</mentor>
+  </person>
+</people>

--- a/src/test/resources/com/zerocracy/bundles/resigns_stale_users_from_project/roles.xml
+++ b/src/test/resources/com/zerocracy/bundles/resigns_stale_users_from_project/roles.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<roles xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.27/xsd/pm/staff/roles.xsd" version="0.1" updated="2017-08-18T13:18:00.000Z">
+  <person id="yegor256">
+    <role>PO</role>
+  </person>
+  <person id="cmiranda">
+    <role>DEV</role>
+  </person>
+</roles>


### PR DESCRIPTION
#924 Users who are absent from people.xml (deleted/kicked out from Zerocracy) are now deleted from projects.

Exception is users who have `PO` role. Some of our clients are logged in to Zerocracy but are not invited, so they are not counted in `people.xml`. Instead, they are added to projects manually as `PO`. We don't want to kick them out of their own projects, which might possibly become orphaned if they are resigned.