### PR TITLE
#1278 Move out init from RqWithUser, move to TestWithUser class

### DIFF
--- a/src/test/java/com/zerocracy/farm/guts/TkGutsTest.java
+++ b/src/test/java/com/zerocracy/farm/guts/TkGutsTest.java
@@ -19,10 +19,10 @@ package com.zerocracy.farm.guts;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.zerocracy.Farm;
 import com.zerocracy.farm.SmartFarm;
-import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.pm.staff.Roles;
 import com.zerocracy.pmo.Pmo;
 import com.zerocracy.tk.RqWithUser;
+import com.zerocracy.tk.TestWithUser;
 import com.zerocracy.tk.TkApp;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
@@ -36,13 +36,13 @@ import org.takes.rs.RsPrint;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-public final class TkGutsTest {
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
+public final class TkGutsTest extends TestWithUser {
 
     @Test
     public void rendersXml() throws Exception {
-        final Farm raw = new FkFarm();
-        new Roles(new Pmo(raw)).bootstrap().assign("yegor256", "PO");
-        try (final Farm farm = new SmartFarm(raw)) {
+        new Roles(new Pmo(this.farm)).bootstrap().assign("yegor256", "PO");
+        try (final Farm farm = new SmartFarm(this.farm)) {
             final Take take = new TkApp(farm);
             MatcherAssert.assertThat(
                 XhtmlMatchers.xhtml(

--- a/src/test/java/com/zerocracy/tk/RqWithUser.java
+++ b/src/test/java/com/zerocracy/tk/RqWithUser.java
@@ -17,10 +17,6 @@
 package com.zerocracy.tk;
 
 import com.zerocracy.Farm;
-import com.zerocracy.pm.staff.Roles;
-import com.zerocracy.pmo.Catalog;
-import com.zerocracy.pmo.People;
-import com.zerocracy.pmo.Pmo;
 import java.io.IOException;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.SolidMap;
@@ -43,14 +39,28 @@ public final class RqWithUser extends RqWrap {
      * @param farm The farm
      * @param req The request
      * @param uid UID of the user making the request
-     * @param init Initialize user and repo
      * @throws IOException If fails
-     * @checkstyle ParameterNumberCheck (3 lines)
      */
-    public RqWithUser(final Farm farm, final Request req, final String uid,
-        final boolean init)
+    public RqWithUser(final Farm farm, final Request req, final String uid)
         throws IOException {
-        super(RqWithUser.make(farm, req, uid, init));
+        super(
+            new RqWithHeaders(
+                req, String.format(
+                    "Cookie: %s=%s",
+                    PsCookie.class.getSimpleName(),
+                    new String(
+                        new CcSecure(farm).encode(
+                            new Identity.Simple(
+                                String.format("urn:github:%s", uid),
+                                new SolidMap<String, String>(
+                                    new MapEntry<>("login", uid)
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        );
     }
 
     /**
@@ -60,50 +70,7 @@ public final class RqWithUser extends RqWrap {
      * @throws IOException If fails
      */
     public RqWithUser(final Farm farm, final Request req) throws IOException {
-        this(farm, req, "yegor256", true);
-    }
-
-    /**
-     * Make it.
-     * @param farm The farm
-     * @param req The request
-     * @param uid UID of the user making the request
-     * @param init Initialize user and repo
-     * @return The request
-     * @throws IOException If fails
-     * @todo #1054:30min The code inside the init if should be extracted into
-     *  another class (a decorator?), as it doesn't belong here at all.
-     * @checkstyle ParameterNumberCheck (3 lines)
-     */
-    private static Request make(final Farm farm, final Request req,
-        final String uid, final boolean init) throws IOException {
-        if (init) {
-            final Catalog catalog = new Catalog(new Pmo(farm)).bootstrap();
-            final String pid = "C00000000";
-            catalog.add(pid, String.format("2017/07/%s/", pid));
-            catalog.link(pid, "github", "test/test");
-            new Roles(
-                farm.find(String.format("@id='%s'", pid)).iterator().next()
-            ).bootstrap().assign(uid, "PO");
-            new People(new Pmo(farm)).bootstrap().invite(uid, "mentor");
-        }
-        return new RqWithHeaders(
-            req,
-            String.format(
-                "Cookie: %s=%s",
-                PsCookie.class.getSimpleName(),
-                new String(
-                    new CcSecure(farm).encode(
-                        new Identity.Simple(
-                            String.format("urn:github:%s", uid),
-                            new SolidMap<String, String>(
-                                new MapEntry<>("login", uid)
-                            )
-                        )
-                    )
-                )
-            )
-        );
+        this(farm, req, "yegor256");
     }
 
 }

--- a/src/test/java/com/zerocracy/tk/TkJoinPostTest.java
+++ b/src/test/java/com/zerocracy/tk/TkJoinPostTest.java
@@ -16,9 +16,6 @@
  */
 package com.zerocracy.tk;
 
-import com.zerocracy.Farm;
-import com.zerocracy.farm.fake.FkFarm;
-import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pmo.People;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -41,17 +38,18 @@ import org.takes.rq.RqWithBody;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class TkJoinPostTest {
+@SuppressWarnings(
+    { "PMD.AvoidDuplicateLiterals", "PMD.TestClassWithoutTestCases" }
+)
+public final class TkJoinPostTest extends TestWithUser {
 
     @Test
     public void acceptRequestAndRedirectOnPost() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
         MatcherAssert.assertThat(
-            new TkApp(farm).act(
+            new TkApp(this.farm).act(
                 new RqWithBody(
                     new RqWithUser(
-                        farm,
+                        this.farm,
                         new RqFake("POST", "/join-post")
                     ),
                     "personality=INTJ-A&stackoverflow=187141"
@@ -66,18 +64,17 @@ public final class TkJoinPostTest {
 
     @Test
     public void rejectsIfAlreadyApplied() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
-        final People people = new People(farm).bootstrap();
+        final People people = new People(this.farm).bootstrap();
         final String uid = "yegor256";
         people.touch(uid);
         people.apply(uid, new Date());
         final RqWithUser req = new RqWithUser(
-            farm,
+            this.farm,
             new RqFake("POST", "/join-post")
         );
         people.breakup(uid);
         MatcherAssert.assertThat(
-            new TkApp(farm).act(
+            new TkApp(this.farm).act(
                 new RqWithBody(
                     req,
                     "personality=INTJ-A&stackoverflow=187241"
@@ -89,17 +86,16 @@ public final class TkJoinPostTest {
 
     @Test
     public void acceptIfNeverApplied() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
-        final People people = new People(farm).bootstrap();
+        final People people = new People(this.farm).bootstrap();
         final String uid = "yegor256";
         people.touch(uid);
         final RqWithUser req = new RqWithUser(
-            farm,
+            this.farm,
             new RqFake("POST", "/join-post")
         );
         people.breakup(uid);
         MatcherAssert.assertThat(
-            new TkApp(farm).act(
+            new TkApp(this.farm).act(
                 new RqWithBody(
                     req,
                     // @checkstyle LineLength (1 line)
@@ -124,21 +120,19 @@ public final class TkJoinPostTest {
     @Test
     @SuppressWarnings("unchecked")
     public void showsThatUserAlreadyHasMentor() throws IOException {
-        final Farm farm = new PropsFarm(new FkFarm());
-        final People people = new People(farm).bootstrap();
+        final People people = new People(this.farm).bootstrap();
         final String mentor = "yoda";
         final String applicant = "luke";
         people.touch(mentor);
         people.touch(applicant);
         people.invite(applicant, mentor, true);
         MatcherAssert.assertThat(
-            new TkApp(farm).act(
+            new TkApp(this.farm).act(
                 new RqWithBody(
                     new RqWithUser(
-                        farm,
+                        this.farm,
                         new RqFake("GET", "/join-post"),
-                        applicant,
-                        false
+                        applicant
                     ),
                     "personality=INTJ-A&stackoverflow=187242"
                 )

--- a/src/test/java/com/zerocracy/tk/TkJoinTest.java
+++ b/src/test/java/com/zerocracy/tk/TkJoinTest.java
@@ -38,8 +38,10 @@ import org.takes.rs.RsPrint;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class TkJoinTest {
+@SuppressWarnings(
+    { "PMD.AvoidDuplicateLiterals", "PMD.TestClassWithoutTestCases" }
+)
+public final class TkJoinTest extends TestWithUser {
 
     @Test
     public void renderJoinPage() throws Exception {
@@ -65,15 +67,14 @@ public final class TkJoinTest {
     @Test
     @Ignore
     public void showsResumeIfAlreadyApplied() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
-        final People people = new People(farm).bootstrap();
+        final People people = new People(this.farm).bootstrap();
         final String uid = "yegor256";
         people.touch(uid);
         people.apply(uid, new Date());
         MatcherAssert.assertThat(
             new RsPrint(
-                new TkApp(farm).act(
-                    new RqWithUser(farm, new RqFake("GET", "/join"))
+                new TkApp(this.farm).act(
+                    new RqWithUser(this.farm, new RqFake("GET", "/join"))
                 )
             ).printBody(),
             new StringContainsInOrder(

--- a/src/test/java/com/zerocracy/tk/TkTeamTest.java
+++ b/src/test/java/com/zerocracy/tk/TkTeamTest.java
@@ -19,9 +19,7 @@ package com.zerocracy.tk;
 import com.jcabi.aspects.Tv;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.zerocracy.Farm;
-import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.fake.FkProject;
-import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pmo.Awards;
 import com.zerocracy.pmo.People;
 import java.io.IOException;
@@ -42,21 +40,22 @@ import org.takes.rs.RsPrint;
  * @checkstyle MagicNumber (500 lines)
  * @checkstyle ClassDataAbstractionCoupling (3 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class TkTeamTest {
+@SuppressWarnings(
+    { "PMD.AvoidDuplicateLiterals", "PMD.TestClassWithoutTestCases" }
+)
+public final class TkTeamTest extends TestWithUser {
 
     @Test
     public void showsSpeedInDays() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
-        final People people = new People(farm).bootstrap();
+        final People people = new People(this.farm).bootstrap();
         final String user = "yegor256";
         people.touch(user);
         people.speed(user, 2880.0);
-        new Awards(farm, user).bootstrap().add(
+        new Awards(this.farm, user).bootstrap().add(
             new FkProject(), 1, "none", "reason", new Date()
         );
         MatcherAssert.assertThat(
-            XhtmlMatchers.xhtml(this.responseBody(farm)),
+            XhtmlMatchers.xhtml(this.responseBody(this.farm)),
             XhtmlMatchers.hasXPaths(
                 String.format("//xhtml:td[.='%s']", 2.0)
             )
@@ -65,16 +64,15 @@ public final class TkTeamTest {
 
     @Test
     public void showsNumberOfJobsInAgenda() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
-        final People people = new People(farm).bootstrap();
+        final People people = new People(this.farm).bootstrap();
         final String user = "yegor256";
         people.touch(user);
-        new Awards(farm, user).bootstrap().add(
+        new Awards(this.farm, user).bootstrap().add(
             new FkProject(), 1, "none", "reason", new Date()
         );
         people.jobs(user, Tv.TEN);
         MatcherAssert.assertThat(
-            XhtmlMatchers.xhtml(this.responseBody(farm)),
+            XhtmlMatchers.xhtml(this.responseBody(this.farm)),
             XhtmlMatchers.hasXPaths(
                 String.format("//xhtml:td[.='%s']", Tv.TEN)
             )
@@ -83,23 +81,22 @@ public final class TkTeamTest {
 
     @Test
     public void showsActiveUsers() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
-        final People people = new People(farm).bootstrap();
+        final People people = new People(this.farm).bootstrap();
         final String active = "g4s8";
         people.touch(active);
         people.invite(active, "yegor256");
-        new Awards(farm, active).bootstrap().add(
+        new Awards(this.farm, active).bootstrap().add(
             new FkProject(), 1, "none", "reason1", new Date()
         );
         final String inactive = "krzyk";
         people.touch(inactive);
         people.invite(inactive, "yegor256");
-        new Awards(farm, inactive).bootstrap().add(
+        new Awards(this.farm, inactive).bootstrap().add(
             new FkProject(), 2, "none", "reason2",
             new Date(Instant.now().minus(Duration.ofDays(91)).toEpochMilli())
         );
         MatcherAssert.assertThat(
-            XhtmlMatchers.xhtml(this.responseBody(farm)),
+            XhtmlMatchers.xhtml(this.responseBody(this.farm)),
             Matchers.allOf(
                 XhtmlMatchers.hasXPaths(
                     String.format("//xhtml:a[.='@%s']", active)

--- a/src/test/java/com/zerocracy/tk/TkVacanciesTest.java
+++ b/src/test/java/com/zerocracy/tk/TkVacanciesTest.java
@@ -31,7 +31,8 @@ import org.takes.rs.RsPrint;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class TkVacanciesTest {
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
+public final class TkVacanciesTest extends TestWithUser {
     @Test
     public void rendersVacanciesPage() throws Exception {
         final Farm farm = new PropsFarm(new FkFarm());

--- a/src/test/java/com/zerocracy/tk/profile/TkAgendaTest.java
+++ b/src/test/java/com/zerocracy/tk/profile/TkAgendaTest.java
@@ -17,14 +17,12 @@
 package com.zerocracy.tk.profile;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import com.zerocracy.Farm;
 import com.zerocracy.Project;
-import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.fake.FkProject;
-import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pmo.Agenda;
 import com.zerocracy.pmo.People;
 import com.zerocracy.tk.RqWithUser;
+import com.zerocracy.tk.TestWithUser;
 import com.zerocracy.tk.TkApp;
 import com.zerocracy.tk.View;
 import java.net.HttpURLConnection;
@@ -40,15 +38,16 @@ import org.takes.rs.RsPrint;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class TkAgendaTest {
+@SuppressWarnings(
+    { "PMD.AvoidDuplicateLiterals", "PMD.TestClassWithoutTestCases" }
+)
+public final class TkAgendaTest extends TestWithUser {
 
     @Test
     public void rendersXmlAgendaPage() throws Exception {
         MatcherAssert.assertThat(
             XhtmlMatchers.xhtml(
-                new View(new PropsFarm(new FkFarm()), "/u/yegor256/agenda")
-                    .xml()
+                new View(this.farm, "/u/yegor256/agenda").xml()
             ),
             XhtmlMatchers.hasXPaths("/page")
         );
@@ -59,9 +58,7 @@ public final class TkAgendaTest {
         MatcherAssert.assertThat(
             XhtmlMatchers.xhtml(
                 XhtmlMatchers.xhtml(
-                    new View(
-                        new PropsFarm(new FkFarm()), "/u/yegor256/agenda"
-                    ).html()
+                    new View(this.farm, "/u/yegor256/agenda").html()
                 )
             ),
             XhtmlMatchers.hasXPaths("//xhtml:body")
@@ -71,13 +68,12 @@ public final class TkAgendaTest {
     @Test
     public void redirectsWhenAccessingNonexistentUsersAgenda()
         throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
-        new People(farm).bootstrap().touch("yegor256");
+        new People(this.farm).bootstrap().touch("yegor256");
         MatcherAssert.assertThat(
             new RsPrint(
-                new TkApp(farm).act(
+                new TkApp(this.farm).act(
                     new RqWithUser(
-                        farm,
+                        this.farm,
                         new RqFake("GET", "/u/foo-user/agenda")
                     )
                 )
@@ -88,8 +84,7 @@ public final class TkAgendaTest {
 
     @Test
     public void rendersAgendaPage() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
-        final Agenda agenda = new Agenda(farm, "yegor256").bootstrap();
+        final Agenda agenda = new Agenda(this.farm, "yegor256").bootstrap();
         final Project project = new FkProject();
         final String job = "gh:test/test#2";
         agenda.add(project, job, "DEV");
@@ -97,7 +92,7 @@ public final class TkAgendaTest {
         agenda.title(job, title);
         MatcherAssert.assertThat(
             XhtmlMatchers.xhtml(
-                new View(farm, "/u/yegor256/agenda").html()
+                new View(this.farm, "/u/yegor256/agenda").html()
             ),
             XhtmlMatchers.hasXPaths(
                 String.format("//xhtml:td[.='%s']", title)

--- a/src/test/java/com/zerocracy/tk/profile/TkAwardsTest.java
+++ b/src/test/java/com/zerocracy/tk/profile/TkAwardsTest.java
@@ -17,11 +17,9 @@
 package com.zerocracy.tk.profile;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import com.zerocracy.Farm;
-import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.fake.FkProject;
-import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.pmo.Awards;
+import com.zerocracy.tk.TestWithUser;
 import com.zerocracy.tk.View;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -33,15 +31,15 @@ import org.junit.Test;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-public final class TkAwardsTest {
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
+public final class TkAwardsTest extends TestWithUser {
 
     @Test
     public void rendersXmlAwardsPage() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
         MatcherAssert.assertThat(
             XhtmlMatchers.xhtml(
                 XhtmlMatchers.xhtml(
-                    new View(farm, "/u/yegor256/awards").html()
+                    new View(this.farm, "/u/yegor256/awards").html()
                 )
             ),
             XhtmlMatchers.hasXPaths("//xhtml:body")
@@ -50,13 +48,12 @@ public final class TkAwardsTest {
 
     @Test
     public void rendersHtmlAwardsPageForFirefox() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
         final String user = "yegor256";
         final int points = 1234;
-        new Awards(farm, user).bootstrap()
+        new Awards(this.farm, user).bootstrap()
             .add(new FkProject(), points, "none", "reason");
         final String html = new View(
-            farm, String.format("/u/%s/awards", user)
+            this.farm, String.format("/u/%s/awards", user)
         ).html();
         MatcherAssert.assertThat(
             html,

--- a/src/test/java/com/zerocracy/tk/profile/TkIdentifyTest.java
+++ b/src/test/java/com/zerocracy/tk/profile/TkIdentifyTest.java
@@ -17,10 +17,8 @@
 package com.zerocracy.tk.profile;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import com.zerocracy.Farm;
-import com.zerocracy.farm.fake.FkFarm;
-import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.tk.RqWithUser;
+import com.zerocracy.tk.TestWithUser;
 import com.zerocracy.tk.TkApp;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
@@ -33,17 +31,17 @@ import org.takes.rs.RsPrint;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-public final class TkIdentifyTest {
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
+public final class TkIdentifyTest extends TestWithUser {
 
     @Test
     public void rendersHomePage() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
         MatcherAssert.assertThat(
             XhtmlMatchers.xhtml(
                 new RsPrint(
-                    new TkApp(farm).act(
+                    new TkApp(this.farm).act(
                         new RqWithUser(
-                            farm,
+                            this.farm,
                             new RqFake("GET", "/identify")
                         )
                     )

--- a/src/test/java/com/zerocracy/tk/profile/TkProfileTest.java
+++ b/src/test/java/com/zerocracy/tk/profile/TkProfileTest.java
@@ -31,6 +31,7 @@ import com.zerocracy.pmo.People;
 import com.zerocracy.pmo.Pmo;
 import com.zerocracy.pmo.Projects;
 import com.zerocracy.tk.RqWithUser;
+import com.zerocracy.tk.TestWithUser;
 import com.zerocracy.tk.TkApp;
 import com.zerocracy.tk.View;
 import java.net.URLEncoder;
@@ -53,8 +54,14 @@ import org.takes.rs.RsPrint;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.ExcessiveImports"})
-public final class TkProfileTest {
+@SuppressWarnings(
+    {
+        "PMD.AvoidDuplicateLiterals",
+        "PMD.ExcessiveImports",
+        "PMD.TestClassWithoutTestCases"
+    }
+)
+public final class TkProfileTest extends TestWithUser {
 
     /**
      * Temporary folder.
@@ -64,31 +71,29 @@ public final class TkProfileTest {
 
     @Test
     public void rendersHomePage() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
         final String uid = "yegor";
-        new Awards(farm, uid).bootstrap().add(
+        new Awards(this.farm, uid).bootstrap().add(
             new FkProject(), 1, "gh:test/test#1", "reason"
         );
-        new Agenda(farm, uid).bootstrap().add(
+        new Agenda(this.farm, uid).bootstrap().add(
             new FkProject(), "gh:test/test#2", "QA"
         );
         MatcherAssert.assertThat(
-            XhtmlMatchers.xhtml(new View(farm, "/u/Yegor256").html()),
+            XhtmlMatchers.xhtml(new View(this.farm, "/u/Yegor256").html()),
             XhtmlMatchers.hasXPaths("//xhtml:body")
         );
     }
 
     @Test
     public void rendersProfilePageWithRateInFirefox() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
         final double rate = 99.99;
-        final People people = new People(farm).bootstrap();
+        final People people = new People(this.farm).bootstrap();
         people.wallet("yegor256", "paypal", "test@example.com");
         people.rate(
             "yegor256", new Cash.S(String.format("USD %f", rate))
         );
         MatcherAssert.assertThat(
-            new View(farm, "/u/yegor256").html(),
+            new View(this.farm, "/u/yegor256").html(),
             Matchers.containsString(
                 String.format(
                     "rate</a> is <span style=\"color:darkgreen\">$%.2f</span>",
@@ -100,10 +105,9 @@ public final class TkProfileTest {
 
     @Test
     public void rendersProfilePageInFirefoxWithReputation() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
         final String user = "yegor256";
         MatcherAssert.assertThat(
-            new View(farm, String.format("/u/%s", user)).html(),
+            new View(this.farm, String.format("/u/%s", user)).html(),
             XhtmlMatchers.hasXPath(
                 String.format(
                     "//xhtml:a[@href='https://github.com/%s']",
@@ -115,22 +119,20 @@ public final class TkProfileTest {
 
     @Test
     public void rendersProfilePageWithoutRateInFirefox() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
-        final People people = new People(farm).bootstrap();
+        final People people = new People(this.farm).bootstrap();
         final String uid = "yegor256";
         people.wallet(
             uid, "btc", "3HcEB6bi4TFPdvk31Pwz77DwAzfAZz2fMn"
         );
         MatcherAssert.assertThat(
-            new View(farm, String.format("/u/%s", uid)).html(),
+            new View(this.farm, String.format("/u/%s", uid)).html(),
             Matchers.containsString("rate</a> is not defined")
         );
     }
 
     @Test
     public void rendersDebts() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
-        final Debts debts = new Debts(farm).bootstrap();
+        final Debts debts = new Debts(this.farm).bootstrap();
         final String uid = "yegor256";
         final String first = "details 1";
         final String second = "details 2";
@@ -139,7 +141,8 @@ public final class TkProfileTest {
         final String reason = "reason";
         debts.add(uid, new Cash.S(price), first, reason);
         debts.add(uid, new Cash.S(amount), second, reason);
-        final String html = new View(farm, String.format("/u/%s", uid)).html();
+        final String html =
+            new View(this.farm, String.format("/u/%s", uid)).html();
         MatcherAssert.assertThat(
             html,
             Matchers.allOf(
@@ -189,8 +192,7 @@ public final class TkProfileTest {
                                 ),
                                 ""
                             ),
-                            uid,
-                            false
+                            uid
                         )
                     )
                 ).printBody()
@@ -210,7 +212,7 @@ public final class TkProfileTest {
             // @checkstyle LineLength (1 line)
             "@nvseenu is not invited to us yet, see <a href=\"www.zerocracy.com/policy.html#1\">§1</a>";
         MatcherAssert.assertThat(
-            new View(new PropsFarm(new FkFarm()), "/").html(
+            new View(this.farm, "/").html(
                 new FormattedText(
                     "Cookie: RsFlash=%s/WARNING",
                     URLEncoder.encode(flash, StandardCharsets.UTF_8.toString())

--- a/src/test/java/com/zerocracy/tk/profile/TkUserWbsTest.java
+++ b/src/test/java/com/zerocracy/tk/profile/TkUserWbsTest.java
@@ -38,6 +38,7 @@ import org.takes.rs.RsPrint;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
 public final class TkUserWbsTest {
 
     @Test
@@ -63,8 +64,7 @@ public final class TkUserWbsTest {
                             ),
                             ""
                         ),
-                        uid,
-                        false
+                        uid
                     )
                 )
             ).printBody(),

--- a/src/test/java/com/zerocracy/tk/project/TkArtifactTest.java
+++ b/src/test/java/com/zerocracy/tk/project/TkArtifactTest.java
@@ -17,10 +17,8 @@
 package com.zerocracy.tk.project;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import com.zerocracy.Farm;
-import com.zerocracy.farm.fake.FkFarm;
-import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.tk.RqWithUser;
+import com.zerocracy.tk.TestWithUser;
 import com.zerocracy.tk.TkApp;
 import java.net.HttpURLConnection;
 import org.hamcrest.MatcherAssert;
@@ -37,12 +35,14 @@ import org.takes.rs.RsPrint;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class TkArtifactTest {
+@SuppressWarnings(
+    { "PMD.AvoidDuplicateLiterals", "PMD.TestClassWithoutTestCases" }
+)
+public final class TkArtifactTest extends TestWithUser {
 
     @Test
     public void rejectsAbsentProject() throws Exception {
-        final Take take = new TkApp(new PropsFarm(new FkFarm()));
+        final Take take = new TkApp(this.farm);
         MatcherAssert.assertThat(
             take.act(
                 new RqFake(
@@ -56,13 +56,12 @@ public final class TkArtifactTest {
 
     @Test
     public void rendersHomePage() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
         MatcherAssert.assertThat(
             XhtmlMatchers.xhtml(
                 new RsPrint(
-                    new TkApp(farm).act(
+                    new TkApp(this.farm).act(
                         new RqWithUser(
-                            farm,
+                            this.farm,
                             new RqFake(
                                 "GET",
                                 "/a/C00000000?a=pm/staff/roles"
@@ -77,11 +76,10 @@ public final class TkArtifactTest {
 
     @Test
     public void rendersWithoutChromeNotice() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
         final String get = new RsPrint(
-            new TkApp(farm).act(
+            new TkApp(this.farm).act(
                 new RqWithUser(
-                    farm,
+                    this.farm,
                     new RqFake(
                         "GET",
                         "/a/C00000000?a=pm/staff/roles"

--- a/src/test/java/com/zerocracy/tk/project/TkClaimTest.java
+++ b/src/test/java/com/zerocracy/tk/project/TkClaimTest.java
@@ -26,9 +26,8 @@ import com.zerocracy.claims.ClaimOut;
 import com.zerocracy.claims.Claims;
 import com.zerocracy.claims.ClaimsItem;
 import com.zerocracy.entry.ClaimsOf;
-import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.footprint.FtFarm;
-import com.zerocracy.farm.props.PropsFarm;
+import com.zerocracy.tk.TestWithUser;
 import com.zerocracy.tk.View;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
@@ -40,12 +39,14 @@ import org.junit.Test;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class TkClaimTest {
+@SuppressWarnings(
+    { "PMD.AvoidDuplicateLiterals", "PMD.TestClassWithoutTestCases" }
+)
+public final class TkClaimTest extends TestWithUser {
 
     @Test
     public void renderClaimWithNoChildrenXml() throws Exception {
-        final Farm farm = new FtFarm(new PropsFarm(new FkFarm()));
+        final Farm farm = new FtFarm(this.farm);
         final long cid = 42L;
         final ClaimOut claim = new ClaimOut().type("test").cid(cid);
         final Project project = farm.find("@id='C00000000'").iterator().next();
@@ -65,7 +66,7 @@ public final class TkClaimTest {
 
     @Test
     public void renderClaimWithOneChild() throws Exception {
-        final FtFarm farm = new FtFarm(new PropsFarm(new FkFarm()));
+        final FtFarm farm = new FtFarm(this.farm);
         final long parent = 111L;
         final long child = 222L;
         final Project proj = farm.find("@id='C00000000'").iterator().next();
@@ -89,7 +90,7 @@ public final class TkClaimTest {
 
     @Test
     public void renderClaimWithManyChildren() throws Exception {
-        final FtFarm farm = new FtFarm(new PropsFarm(new FkFarm()));
+        final FtFarm farm = new FtFarm(this.farm);
         final long parent = 164L;
         final int children = Tv.FIFTY;
         final Project proj = farm.find("@id='C00000000'").iterator().next();

--- a/src/test/java/com/zerocracy/tk/project/TkFootprintTest.java
+++ b/src/test/java/com/zerocracy/tk/project/TkFootprintTest.java
@@ -18,15 +18,13 @@ package com.zerocracy.tk.project;
 
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XML;
-import com.zerocracy.Farm;
 import com.zerocracy.Project;
 import com.zerocracy.claims.ClaimOut;
 import com.zerocracy.claims.ClaimsItem;
 import com.zerocracy.claims.Footprint;
 import com.zerocracy.entry.ClaimsOf;
-import com.zerocracy.farm.fake.FkFarm;
-import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.tk.RqWithUser;
+import com.zerocracy.tk.TestWithUser;
 import com.zerocracy.tk.TkApp;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -40,18 +38,19 @@ import org.takes.rs.RsPrint;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class TkFootprintTest {
+@SuppressWarnings(
+    { "PMD.AvoidDuplicateLiterals", "PMD.TestClassWithoutTestCases" }
+)
+public final class TkFootprintTest extends TestWithUser {
 
     @Test
     public void rendersListOfClaims() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
         MatcherAssert.assertThat(
             XhtmlMatchers.xhtml(
                 new RsPrint(
-                    new TkApp(farm).act(
+                    new TkApp(this.farm).act(
                         new RqWithUser(
-                            farm,
+                            this.farm,
                             new RqFake(
                                 "GET",
                                 "/footprint/C00000000"
@@ -66,18 +65,18 @@ public final class TkFootprintTest {
 
     @Test
     public void rendersListOfClaimsAsText() throws Exception {
-        final Farm farm = new PropsFarm();
-        final Project project = farm.find("@id='C00000000'").iterator().next();
-        new ClaimOut().type("Hello").postTo(new ClaimsOf(farm, project));
+        final Project project =
+            this.farm.find("@id='C00000000'").iterator().next();
+        new ClaimOut().type("Hello").postTo(new ClaimsOf(this.farm, project));
         final XML xml = new ClaimsItem(project).iterate().iterator().next();
-        try (final Footprint footprint = new Footprint(farm, project)) {
+        try (final Footprint footprint = new Footprint(this.farm, project)) {
             footprint.open(xml, "test");
             footprint.close(xml);
             MatcherAssert.assertThat(
                 new RsPrint(
-                    new TkApp(farm).act(
+                    new TkApp(this.farm).act(
                         new RqWithUser(
-                            farm,
+                            this.farm,
                             new RqFake(
                                 "GET",
                                 "/footprint/C00000000?format=plain"

--- a/src/test/java/com/zerocracy/tk/project/TkReportTest.java
+++ b/src/test/java/com/zerocracy/tk/project/TkReportTest.java
@@ -21,9 +21,8 @@ import com.zerocracy.Farm;
 import com.zerocracy.Project;
 import com.zerocracy.claims.ClaimOut;
 import com.zerocracy.entry.ClaimsOf;
-import com.zerocracy.farm.fake.FkFarm;
 import com.zerocracy.farm.footprint.FtFarm;
-import com.zerocracy.farm.props.PropsFarm;
+import com.zerocracy.tk.TestWithUser;
 import com.zerocracy.tk.View;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
@@ -34,11 +33,12 @@ import org.junit.Test;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-public final class TkReportTest {
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
+public final class TkReportTest extends TestWithUser {
 
     @Test
     public void rendersReport() throws Exception {
-        final Farm farm = new FtFarm(new PropsFarm(new FkFarm()));
+        final Farm farm = new FtFarm(this.farm);
         final String uid = "yegor256";
         final Project project = farm.find("@id='C00000000'").iterator().next();
         new ClaimOut()

--- a/src/test/java/com/zerocracy/tk/project/TkXmlTest.java
+++ b/src/test/java/com/zerocracy/tk/project/TkXmlTest.java
@@ -17,10 +17,8 @@
 package com.zerocracy.tk.project;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import com.zerocracy.Farm;
-import com.zerocracy.farm.fake.FkFarm;
-import com.zerocracy.farm.props.PropsFarm;
 import com.zerocracy.tk.RqWithUser;
+import com.zerocracy.tk.TestWithUser;
 import com.zerocracy.tk.TkApp;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
@@ -33,17 +31,17 @@ import org.takes.rs.RsPrint;
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-public final class TkXmlTest {
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
+public final class TkXmlTest extends TestWithUser {
 
     @Test
     public void rendersSingleArtifact() throws Exception {
-        final Farm farm = new PropsFarm(new FkFarm());
         MatcherAssert.assertThat(
             XhtmlMatchers.xhtml(
                 new RsPrint(
-                    new TkApp(farm).act(
+                    new TkApp(this.farm).act(
                         new RqWithUser(
-                            farm,
+                            this.farm,
                             new RqFake(
                                 "GET",
                                 "/xml/C00000000?file=roles.xml"


### PR DESCRIPTION
#1278:

* Moved out `if (init)` block from `RqWithUser` and moved it to `TestWithUser` class.
* Test cases using `RqWithUser` and `View` now extend `TestWithUser`

Note: PMD suppression of `TestClassWithoutTestCases` is due to a PMD bug with the Qulice version we are using, please see https://sourceforge.net/p/pmd/bugs/1453/