### PR TITLE
#1662 Add puzzle for Ledger Postgres implementation

### DIFF
--- a/src/main/java/com/zerocracy/pm/cost/Ledger.java
+++ b/src/main/java/com/zerocracy/pm/cost/Ledger.java
@@ -32,6 +32,13 @@ import org.xembly.Directives;
  * Ledger.
  *
  * @since 1.0
+ * @todo #1662:30min Ledger is really slow when it grows big. Performance
+ *  degrades linearly (O(n)) with the size of the ledger due to the need
+ *  to perform ID lookups. The slowdown is roughly 50ms per 1000 entries.
+ *  See https://github.com/zerocracy/farm/issues/1662#issuecomment-416454156
+ *  for details. Let's move away from using XML and record entries using
+ *  Postgres. For more info see
+ *  https://github.com/zerocracy/farm/issues/1662#issuecomment-422759929
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class Ledger {


### PR DESCRIPTION
#1662: We found the slowdown in `make_payment` is due to `Ledger`, see https://github.com/zerocracy/farm/issues/1662#issuecomment-416454156.

Added a puzzle for migrating to Postgres.