### PR TITLE
Properly parse rate in set_rate command

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pmo/profile/set_rate.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pmo/profile/set_rate.groovy
@@ -46,7 +46,7 @@ def exec(Project pmo, XML xml) {
   }
   Cash rate
   try {
-    rate = new Cash.S(claim.param('rate').replaceAll('([A-Z]{3})$', ' \1'))
+    rate = new Cash.S(claim.param('rate').replaceAll('(.*)([A-Z]{3})$', '$2 $1'))
   } catch (CashParsingException ex) {
     throw new SoftException(
       new Par(

--- a/src/main/java/com/zerocracy/claims/ClaimSignature.java
+++ b/src/main/java/com/zerocracy/claims/ClaimSignature.java
@@ -77,7 +77,7 @@ public final class ClaimSignature implements Text {
                     "%s=%s", entry.getKey(), entry.getValue()
                 ),
                 new Sorted<>(
-                    Comparator.comparing(Map.Entry::getKey),
+                    Comparator.comparing(Map.Entry<String, String>::getKey),
                     claim.params().entrySet()
                 )
             );

--- a/src/test/resources/com/zerocracy/bundles/set_user_rate_eur/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/set_user_rate_eur/_after.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.set_user_rate_eur
+
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.cash.Cash
+import com.zerocracy.pmo.People
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  MatcherAssert.assertThat(
+    new People(farm).rate('user42'),
+    Matchers.comparesEqualTo(new Cash.S('EUR 100'))
+  )
+}

--- a/src/test/resources/com/zerocracy/bundles/set_user_rate_eur/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/set_user_rate_eur/_before.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.set_user_rate_eur
+
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.pmo.People
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  new People(farm).bootstrap().details('user42', 'something')
+}

--- a/src/test/resources/com/zerocracy/bundles/set_user_rate_eur/_setup.xml
+++ b/src/test/resources/com/zerocracy/bundles/set_user_rate_eur/_setup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<setup>
+  <pmo>true</pmo>
+</setup>

--- a/src/test/resources/com/zerocracy/bundles/set_user_rate_eur/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/set_user_rate_eur/claims.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:28Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pm/claims.xsd">
+  <claim id="1">
+    <created>2017-07-21T20:32:19.716Z</created>
+    <type>Set wallet</type>
+    <token>test;C123;user42</token>
+    <author>user42</author>
+    <params>
+      <param name="bank">paypal</param>
+      <param name="wallet">test@example.com</param>
+    </params>
+  </claim>
+  <claim id="2">
+    <created>2017-07-21T20:32:19.716Z</created>
+    <type>Set rate</type>
+    <token>test;C123;user42</token>
+    <author>user42</author>
+    <params>
+      <param name="rate">100EUR</param>
+    </params>
+  </claim>
+</claims>

--- a/src/test/resources/com/zerocracy/bundles/set_user_rate_eur/people.xml
+++ b/src/test/resources/com/zerocracy/bundles/set_user_rate_eur/people.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<people xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:29Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pmo/people.xsd">
+  <person id="user42">
+    <mentor>yegor256</mentor>
+    <reputation>0</reputation>
+    <projects>0</projects>
+    <jobs>0</jobs>
+    <skills updated="2018-02-22T18:35:15.684Z"/>
+    <applied>2018-01-01T00:00:00.000Z</applied>
+    <speed>0.0</speed>
+  </person>
+</people>


### PR DESCRIPTION
This is for #1282

- The `set_rate` was incorrectly implemented and \1 was used instead of $1 to rewrite "100EUR" into "100 EUR", this resulted in an exception that was never reported back to the user because of #1736.
- Moreover `Cash.S` was expecting a string in the format "EUR 100" and not "100 EUR".