### PR TITLE
#1278 Moved initialization code in RqWithUser to new decorator class

### DIFF
--- a/src/test/java/com/zerocracy/farm/guts/TkGutsTest.java
+++ b/src/test/java/com/zerocracy/farm/guts/TkGutsTest.java
@@ -48,7 +48,7 @@ public final class TkGutsTest {
                 XhtmlMatchers.xhtml(
                     new RsPrint(
                         take.act(
-                            new RqWithUser(
+                            new RqWithUser.WithInit(
                                 farm, new RqFake("GET", "/guts")
                             )
                         )

--- a/src/test/java/com/zerocracy/tk/RqWithUser.java
+++ b/src/test/java/com/zerocracy/tk/RqWithUser.java
@@ -22,8 +22,11 @@ import com.zerocracy.pmo.Catalog;
 import com.zerocracy.pmo.People;
 import com.zerocracy.pmo.Pmo;
 import java.io.IOException;
+import java.io.InputStream;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.SolidMap;
+import org.cactoos.scalar.StickyScalar;
+import org.cactoos.scalar.UncheckedScalar;
 import org.takes.Request;
 import org.takes.facets.auth.Identity;
 import org.takes.facets.auth.PsCookie;
@@ -43,67 +46,90 @@ public final class RqWithUser extends RqWrap {
      * @param farm The farm
      * @param req The request
      * @param uid UID of the user making the request
-     * @param init Initialize user and repo
      * @throws IOException If fails
      * @checkstyle ParameterNumberCheck (3 lines)
      */
-    public RqWithUser(final Farm farm, final Request req, final String uid,
-        final boolean init)
+    public RqWithUser(final Farm farm, final Request req, final String uid)
         throws IOException {
-        super(RqWithUser.make(farm, req, uid, init));
-    }
-
-    /**
-     * Ctor.
-     * @param farm The farm
-     * @param req The request
-     * @throws IOException If fails
-     */
-    public RqWithUser(final Farm farm, final Request req) throws IOException {
-        this(farm, req, "yegor256", true);
-    }
-
-    /**
-     * Make it.
-     * @param farm The farm
-     * @param req The request
-     * @param uid UID of the user making the request
-     * @param init Initialize user and repo
-     * @return The request
-     * @throws IOException If fails
-     * @todo #1054:30min The code inside the init if should be extracted into
-     *  another class (a decorator?), as it doesn't belong here at all.
-     * @checkstyle ParameterNumberCheck (3 lines)
-     */
-    private static Request make(final Farm farm, final Request req,
-        final String uid, final boolean init) throws IOException {
-        if (init) {
-            final Catalog catalog = new Catalog(new Pmo(farm)).bootstrap();
-            final String pid = "C00000000";
-            catalog.add(pid, String.format("2017/07/%s/", pid));
-            catalog.link(pid, "github", "test/test");
-            new Roles(
-                farm.find(String.format("@id='%s'", pid)).iterator().next()
-            ).bootstrap().assign(uid, "PO");
-            new People(new Pmo(farm)).bootstrap().invite(uid, "mentor");
-        }
-        return new RqWithHeaders(
-            req,
-            String.format(
-                "Cookie: %s=%s",
-                PsCookie.class.getSimpleName(),
-                new String(
-                    new CcSecure(farm).encode(
-                        new Identity.Simple(
-                            String.format("urn:github:%s", uid),
-                            new SolidMap<String, String>(
-                                new MapEntry<>("login", uid)
+        super(
+            new RqWithHeaders(
+                req,
+                String.format(
+                    "Cookie: %s=%s",
+                    PsCookie.class.getSimpleName(),
+                    new String(
+                        new CcSecure(farm).encode(
+                            new Identity.Simple(
+                                String.format("urn:github:%s", uid),
+                                new SolidMap<String, String>(
+                                    new MapEntry<>("login", uid)
+                                )
                             )
                         )
                     )
                 )
             )
         );
+    }
+
+    /**
+     * With initialized user and repo.
+     */
+    public static final class WithInit implements Request {
+        /**
+         * Underlying request.
+         */
+        private final UncheckedScalar<RqWithUser> req;
+
+        /**
+         * Ctor.
+         * @param farm The farm
+         * @param req The request
+         * @throws IOException If fails
+         */
+        public WithInit(final Farm farm, final Request req)
+            throws IOException {
+            this(farm, req, "yegor256");
+        }
+
+        /**
+         * Ctor.
+         * @param farm The farm
+         * @param req The request
+         * @param uid UID of the user making the request
+         * @throws IOException If fails
+         */
+        public WithInit(final Farm farm, final Request req, final String uid)
+            throws IOException {
+            this.req = new UncheckedScalar<>(
+                new StickyScalar<>(
+                    () -> {
+                        final Catalog catalog =
+                            new Catalog(new Pmo(farm)).bootstrap();
+                        final String pid = "C00000000";
+                        catalog.add(pid, String.format("2017/07/%s/", pid));
+                        catalog.link(pid, "github", "test/test");
+                        new Roles(
+                            farm.find(String.format("@id='%s'", pid))
+                                .iterator().next()
+                        ).bootstrap().assign(uid, "PO");
+                        new People(new Pmo(farm)).bootstrap()
+                            .invite(uid, "mentor");
+                        return new RqWithUser(farm, req, uid);
+                    }
+                )
+            );
+        }
+
+        @Override
+        public Iterable<String> head() throws IOException {
+            return this.req.value().head();
+        }
+
+        @Override
+        public InputStream body() throws IOException {
+            return this.req.value().body();
+        }
     }
 
 }

--- a/src/test/java/com/zerocracy/tk/RqWithUser.java
+++ b/src/test/java/com/zerocracy/tk/RqWithUser.java
@@ -25,8 +25,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.SolidMap;
+import org.cactoos.scalar.IoCheckedScalar;
 import org.cactoos.scalar.StickyScalar;
-import org.cactoos.scalar.UncheckedScalar;
 import org.takes.Request;
 import org.takes.facets.auth.Identity;
 import org.takes.facets.auth.PsCookie;
@@ -79,7 +79,7 @@ public final class RqWithUser extends RqWrap {
         /**
          * Underlying request.
          */
-        private final UncheckedScalar<RqWithUser> req;
+        private final IoCheckedScalar<RqWithUser> req;
 
         /**
          * Ctor.
@@ -97,11 +97,9 @@ public final class RqWithUser extends RqWrap {
          * @param farm The farm
          * @param req The request
          * @param uid UID of the user making the request
-         * @throws IOException If fails
          */
-        public WithInit(final Farm farm, final Request req, final String uid)
-            throws IOException {
-            this.req = new UncheckedScalar<>(
+        public WithInit(final Farm farm, final Request req, final String uid) {
+            this.req = new IoCheckedScalar<>(
                 new StickyScalar<>(
                     () -> {
                         final Catalog catalog =

--- a/src/test/java/com/zerocracy/tk/TkJoinPostTest.java
+++ b/src/test/java/com/zerocracy/tk/TkJoinPostTest.java
@@ -29,6 +29,7 @@ import org.cactoos.text.FormattedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.takes.Request;
 import org.takes.facets.hamcrest.HmRsHeader;
 import org.takes.facets.hamcrest.HmRsStatus;
 import org.takes.rq.RqFake;
@@ -50,7 +51,7 @@ public final class TkJoinPostTest {
         MatcherAssert.assertThat(
             new TkApp(farm).act(
                 new RqWithBody(
-                    new RqWithUser(
+                    new RqWithUser.WithInit(
                         farm,
                         new RqFake("POST", "/join-post")
                     ),
@@ -71,7 +72,7 @@ public final class TkJoinPostTest {
         final String uid = "yegor256";
         people.touch(uid);
         people.apply(uid, Instant.now());
-        final RqWithUser req = new RqWithUser(
+        final Request req = new RqWithUser.WithInit(
             farm,
             new RqFake("POST", "/join-post")
         );
@@ -93,9 +94,10 @@ public final class TkJoinPostTest {
         final People people = new People(farm).bootstrap();
         final String uid = "yegor256";
         people.touch(uid);
-        final RqWithUser req = new RqWithUser(
+        final Request req = new RqWithUser(
             farm,
-            new RqFake("POST", "/join-post")
+            new RqFake("POST", "/join-post"),
+            uid
         );
         people.breakup(uid);
         MatcherAssert.assertThat(
@@ -137,8 +139,7 @@ public final class TkJoinPostTest {
                     new RqWithUser(
                         farm,
                         new RqFake("GET", "/join-post"),
-                        applicant,
-                        false
+                        applicant
                     ),
                     "personality=INTJ-A&stackoverflow=187242"
                 )

--- a/src/test/java/com/zerocracy/tk/TkJoinTest.java
+++ b/src/test/java/com/zerocracy/tk/TkJoinTest.java
@@ -48,7 +48,9 @@ public final class TkJoinTest {
             XhtmlMatchers.xhtml(
                 new RsPrint(
                     new TkApp(farm).act(
-                        new RqWithUser(farm, new RqFake("GET", "/join"))
+                        new RqWithUser.WithInit(
+                            farm, new RqFake("GET", "/join")
+                        )
                     )
                 ).printBody()
             ),
@@ -73,7 +75,9 @@ public final class TkJoinTest {
         MatcherAssert.assertThat(
             new RsPrint(
                 new TkApp(farm).act(
-                    new RqWithUser(farm, new RqFake("GET", "/join"))
+                    new RqWithUser.WithInit(
+                        farm, new RqFake("GET", "/join")
+                    )
                 )
             ).printBody(),
             new StringContainsInOrder(

--- a/src/test/java/com/zerocracy/tk/TkTeamTest.java
+++ b/src/test/java/com/zerocracy/tk/TkTeamTest.java
@@ -116,7 +116,7 @@ public final class TkTeamTest {
     private String responseBody(final Farm farm) throws IOException {
         return new RsPrint(
             new TkApp(farm).act(
-                new RqWithUser(
+                new RqWithUser.WithInit(
                     farm,
                     new RqFake(
                         new ListOf<>(

--- a/src/test/java/com/zerocracy/tk/TkVacanciesTest.java
+++ b/src/test/java/com/zerocracy/tk/TkVacanciesTest.java
@@ -39,7 +39,7 @@ public final class TkVacanciesTest {
             XhtmlMatchers.xhtml(
                 new RsPrint(
                     new TkApp(farm).act(
-                        new RqWithUser(
+                        new RqWithUser.WithInit(
                             farm,
                             new RqFake("GET", "/vacancies")
                         )

--- a/src/test/java/com/zerocracy/tk/View.java
+++ b/src/test/java/com/zerocracy/tk/View.java
@@ -93,7 +93,7 @@ public final class View {
         throws IOException {
         return new RsPrint(
             new TkApp(this.farm).act(
-                new RqWithUser(
+                new RqWithUser.WithInit(
                     this.farm,
                     new RqFake(
                         new Joined<String>(

--- a/src/test/java/com/zerocracy/tk/profile/TkAgendaTest.java
+++ b/src/test/java/com/zerocracy/tk/profile/TkAgendaTest.java
@@ -76,7 +76,7 @@ public final class TkAgendaTest {
         MatcherAssert.assertThat(
             new RsPrint(
                 new TkApp(farm).act(
-                    new RqWithUser(
+                    new RqWithUser.WithInit(
                         farm,
                         new RqFake("GET", "/u/foo-user/agenda")
                     )

--- a/src/test/java/com/zerocracy/tk/profile/TkIdentifyTest.java
+++ b/src/test/java/com/zerocracy/tk/profile/TkIdentifyTest.java
@@ -42,7 +42,7 @@ public final class TkIdentifyTest {
             XhtmlMatchers.xhtml(
                 new RsPrint(
                     new TkApp(farm).act(
-                        new RqWithUser(
+                        new RqWithUser.WithInit(
                             farm,
                             new RqFake("GET", "/identify")
                         )

--- a/src/test/java/com/zerocracy/tk/profile/TkProfileTest.java
+++ b/src/test/java/com/zerocracy/tk/profile/TkProfileTest.java
@@ -189,8 +189,7 @@ public final class TkProfileTest {
                                 ),
                                 ""
                             ),
-                            uid,
-                            false
+                            uid
                         )
                     )
                 ).printBody()

--- a/src/test/java/com/zerocracy/tk/profile/TkUserWbsTest.java
+++ b/src/test/java/com/zerocracy/tk/profile/TkUserWbsTest.java
@@ -63,8 +63,7 @@ public final class TkUserWbsTest {
                             ),
                             ""
                         ),
-                        uid,
-                        false
+                        uid
                     )
                 )
             ).printBody(),

--- a/src/test/java/com/zerocracy/tk/project/TkArtifactTest.java
+++ b/src/test/java/com/zerocracy/tk/project/TkArtifactTest.java
@@ -61,7 +61,7 @@ public final class TkArtifactTest {
             XhtmlMatchers.xhtml(
                 new RsPrint(
                     new TkApp(farm).act(
-                        new RqWithUser(
+                        new RqWithUser.WithInit(
                             farm,
                             new RqFake(
                                 "GET",
@@ -80,7 +80,7 @@ public final class TkArtifactTest {
         final Farm farm = new PropsFarm(new FkFarm());
         final String get = new RsPrint(
             new TkApp(farm).act(
-                new RqWithUser(
+                new RqWithUser.WithInit(
                     farm,
                     new RqFake(
                         "GET",

--- a/src/test/java/com/zerocracy/tk/project/TkFootprintTest.java
+++ b/src/test/java/com/zerocracy/tk/project/TkFootprintTest.java
@@ -50,7 +50,7 @@ public final class TkFootprintTest {
             XhtmlMatchers.xhtml(
                 new RsPrint(
                     new TkApp(farm).act(
-                        new RqWithUser(
+                        new RqWithUser.WithInit(
                             farm,
                             new RqFake(
                                 "GET",
@@ -76,7 +76,7 @@ public final class TkFootprintTest {
             MatcherAssert.assertThat(
                 new RsPrint(
                     new TkApp(farm).act(
-                        new RqWithUser(
+                        new RqWithUser.WithInit(
                             farm,
                             new RqFake(
                                 "GET",

--- a/src/test/java/com/zerocracy/tk/project/TkXmlTest.java
+++ b/src/test/java/com/zerocracy/tk/project/TkXmlTest.java
@@ -42,7 +42,7 @@ public final class TkXmlTest {
             XhtmlMatchers.xhtml(
                 new RsPrint(
                     new TkApp(farm).act(
-                        new RqWithUser(
+                        new RqWithUser.WithInit(
                             farm,
                             new RqFake(
                                 "GET",


### PR DESCRIPTION
#1278: Removed the initialization code in `RqWithUser.make()`. New inner decorator class `RqWithUser.WithInit` created, containing the init code within a `StickyScalar` returning a `RqWithUser`.

Changed test classes to use `RqWithUser.WithInit` where appropriate.