### PR TITLE
#1308 Allow running of specific BundlesTests

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,15 @@ the list of claims to be dispatched. There are also a few supplementary files:
 
 More details you can find in the Javadoc section of `BundlesTest`.
 
-You can skip BundlesTest's execution by specifying ``-DskipBundlesTest``:
+The entire `BundlesTest` suite can take a very long amount of time to execute.
+If you are debugging a certain test or function, you can specify the exact tests
+to run by specifying a comma separated list via `-DbundlesTests`. E.g. to run
+the `assign_role` and `cancel_order` tests:
+
+``$mvn clean install -Pqulice -DbundlesTests=assign_role,cancel_order``
+
+Alternatively, you can skip `BundlesTest` suite execution altogether by
+specifying ``-DskipBundlesTest``:
 
 ``$mvn clean install -Pqulice -DskipBundlesTest``
 

--- a/src/test/java/com/zerocracy/BundlesTest.java
+++ b/src/test/java/com/zerocracy/BundlesTest.java
@@ -56,7 +56,7 @@ import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.Mapped;
 import org.cactoos.iterable.Sorted;
 import org.cactoos.list.ListOf;
-import org.cactoos.list.SolidList;
+import org.cactoos.list.StickyList;
 import org.cactoos.scalar.And;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
@@ -147,13 +147,13 @@ public final class BundlesTest {
         final Iterable<Object[]> list;
         final String tests = System.getProperty("bundlesTests", "");
         if (tests.isEmpty()) {
-            list = new Sorted<>(
-                new Mapped<>(
-                    path -> new Object[]{
-                        path.substring(0, path.indexOf("/claims.xml")),
-                    },
+            list = new Mapped<>(
+                path -> new Object[]{
+                    path.substring(0, path.indexOf("/claims.xml")),
+                },
+                new Sorted<>(
                     new Reflections(
-                        "com.zerocracy.bundles", new ResourcesScanner()
+                    "com.zerocracy.bundles", new ResourcesScanner()
                     ).getResources(p -> p.endsWith("claims.xml"))
                 )
             );
@@ -165,7 +165,7 @@ public final class BundlesTest {
                 new ListOf<>(tests.split(","))
             );
         }
-        return new SolidList<>(list);
+        return new StickyList<>(list);
     }
 
     @Before

--- a/src/test/java/com/zerocracy/BundlesTest.java
+++ b/src/test/java/com/zerocracy/BundlesTest.java
@@ -142,18 +142,28 @@ public final class BundlesTest {
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> bundles() {
-        return new SolidList<Object[]>(
-            new Mapped<>(
-                path -> new Object[]{
-                    path.substring(0, path.indexOf("/claims.xml")),
-                },
-                new Sorted<>(
+        final Iterable<Object[]> list;
+        final String tests = System.getProperty("bundlesTests", "");
+        if (tests.isEmpty()) {
+            list = new Sorted<>(
+                new Mapped<>(
+                    path -> new Object[]{
+                        path.substring(0, path.indexOf("/claims.xml")),
+                    },
                     new Reflections(
                         "com.zerocracy.bundles", new ResourcesScanner()
                     ).getResources(p -> p.endsWith("claims.xml"))
                 )
-            )
-        );
+            );
+        } else {
+            list = new Mapped<>(
+                test -> new Object[]{
+                    String.format("com/zerocracy/bundles/%s", test),
+                },
+                new ListOf<>(tests.split(","))
+            );
+        }
+        return new SolidList<>(list);
     }
 
     @Before


### PR DESCRIPTION
#1308: `BundlesTests` changed to allow specification of exact tests to run via `bundlesTests` system property. Added information in `README.md` to specify how to use this.