### PR TITLE
Implement Resumes.resume()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -571,7 +571,7 @@ SOFTWARE.
                       <limit>
                         <counter>CLASS</counter>
                         <value>MISSEDCOUNT</value>
-                        <maximum>93</maximum>
+                        <maximum>94</maximum>
                       </limit>
                     </limits>
                   </rule>

--- a/src/main/java/com/zerocracy/pmo/ResumeXml.java
+++ b/src/main/java/com/zerocracy/pmo/ResumeXml.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.pmo;
+
+import com.jcabi.xml.XML;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Resume stored as xml.
+ *
+ * <p>This class helps you parse the resume XML and take.
+ * Use it everywhere. Don't parse the XML manually.</p>
+ *
+ * @since 1.0
+ */
+public final class ResumeXml implements Resume {
+
+    /**
+     * XML.
+     */
+    private final XML xml;
+
+    /**
+     * Ctor.
+     * @param input Input XML
+     */
+    public ResumeXml(final XML input) {
+        this.xml = input;
+    }
+
+    @Override
+    public String toString() {
+        return this.xml.toString();
+    }
+
+    @Override
+    public Instant submitted() {
+        return LocalDateTime.parse(
+            this.xml.xpath("submitted/text()").get(0),
+            DateTimeFormatter.ISO_LOCAL_DATE_TIME
+        ).toInstant(ZoneOffset.UTC);
+    }
+
+    @Override
+    public String login() {
+        return this.xml.xpath("@login").get(0);
+    }
+
+    @Override
+    public String text() {
+        return this.xml.xpath("text/text()").get(0);
+    }
+
+    @Override
+    public String personality() {
+        return this.xml.xpath("personality/text()").get(0);
+    }
+
+    @Override
+    public long soid() {
+        return Long.parseLong(this.xml.xpath("stackoverflow/text()").get(0));
+    }
+
+    @Override
+    public String telegram() {
+        return this.xml.xpath("telegram/text()").get(0);
+    }
+}

--- a/src/main/java/com/zerocracy/pmo/Resumes.java
+++ b/src/main/java/com/zerocracy/pmo/Resumes.java
@@ -28,13 +28,6 @@ import org.xembly.Directives;
 /**
  * Resumes.
  * @since 1.0
- *
- * @todo #1569:30min Implement resumes.resume(login), which will return the
- *  resume sent for some user. It will have to return a Resume
- *  implementation which reads the resume from resumes.xml. It must read
- *  /resumes/resume attributes and return them in its methods.
- *  Then remove expected from ResumesTest.findResume so it can be tested to
- *  be used in resume page.
  */
 public final class Resumes {
     /**
@@ -84,7 +77,7 @@ public final class Resumes {
     @SuppressWarnings("PMD.UseObjectForClearerAPI")
     public void add(final String login, final LocalDateTime when,
         final String text, final String personality,
-        final int stackoverflow, final String telegram) throws IOException {
+        final long stackoverflow, final String telegram) throws IOException {
         try (final Item item = this.item()) {
             new Xocument(item).modify(
                 new Directives()
@@ -201,7 +194,16 @@ public final class Resumes {
      * @throws IOException If fails or resume not found
      */
     public Resume resume(final String login) throws IOException {
-        throw new UnsupportedOperationException("resume() not implemented");
+        try (final Item item = this.item()) {
+            return new ResumeXml(
+                new Xocument(item.path()).nodes(
+                    new FormattedText(
+                        "/resumes/resume[@login='%s' ]",
+                        login
+                    ).asString()
+                ).get(0)
+            );
+        }
     }
 
     /**

--- a/src/main/java/com/zerocracy/tk/TkJoinPost.java
+++ b/src/main/java/com/zerocracy/tk/TkJoinPost.java
@@ -104,7 +104,7 @@ public final class TkJoinPost implements TkRegex {
         final String telegram = form.single("telegram");
         final String personality = form.single("personality");
         final String about = form.single("about");
-        final int stko = Integer.parseInt(form.single("stackoverflow"));
+        final long stko = Long.parseLong(form.single("stackoverflow"));
         new ClaimOut().type("Join form submitted")
             .author(author)
             .param("telegram", telegram)

--- a/src/test/java/com/zerocracy/pmo/ResumesTest.java
+++ b/src/test/java/com/zerocracy/pmo/ResumesTest.java
@@ -30,15 +30,21 @@ import java.time.ZoneOffset;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.core.IsNull;
 import org.junit.Test;
 
 /**
  * Test case for {@link Resumes}.
  *
  * @since 1.0
+ * @todo #1645:30min Handle resume not found in resumes.resume(login).
+ *  It will have to throw a meaningful message using a SoftException.
+ *  A test should be written to cover this situation.
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class ResumesTest {
     @Test
     public void addsResumes() throws Exception {
@@ -105,23 +111,15 @@ public final class ResumesTest {
         );
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void findResume() throws Exception {
         final Farm farm = new FkFarm();
         final String login = "login";
         final Instant time = Instant.parse("2018-01-01T00:00:00Z");
         final String text = "Resume text";
         final String personality = "ENTP-T";
-        final int id = 187141;
+        final long id = 187141;
         final String telegram = "telegram";
-        final Resume fake = new Resume.Fake(
-            time,
-            login,
-            text,
-            personality,
-            id,
-            telegram
-        );
         final Resumes resumes = new Resumes(farm).bootstrap();
         resumes.add(
             login,
@@ -134,7 +132,156 @@ public final class ResumesTest {
         MatcherAssert.assertThat(
             "Could not find resume",
             resumes.resume(login),
-            new IsEqual<>(fake)
+            new IsNot<>(new IsNull<>())
+        );
+    }
+    @Test
+    public void resumeHasLoginAttribute() throws Exception {
+        final Farm farm = new FkFarm();
+        final String login = "a-login";
+        final Instant time = Instant.parse("2018-01-01T00:00:00Z");
+        final String text = "Resume text";
+        final String personality = "ENTP-T";
+        final long id = 187141;
+        final String telegram = "telegram";
+        final Resumes resumes = new Resumes(farm).bootstrap();
+        resumes.add(
+            login,
+            LocalDateTime.ofInstant(time, ZoneOffset.UTC),
+            text,
+            personality,
+            id,
+            telegram
+        );
+        MatcherAssert.assertThat(
+            "Could not find resume",
+            resumes.resume(login).login(),
+            new IsEqual<>(login)
+        );
+    }
+
+    @Test
+    public void resumeHasSubmittedTime() throws Exception {
+        final Farm farm = new FkFarm();
+        final String login = "a-login";
+        final Instant time = Instant.parse("2018-01-01T00:00:00Z");
+        final String text = "Resume text";
+        final String personality = "ENTP-T";
+        final long id = 187141;
+        final String telegram = "telegram";
+        final Resumes resumes = new Resumes(farm).bootstrap();
+        resumes.add(
+            login,
+            LocalDateTime.ofInstant(time, ZoneOffset.UTC),
+            text,
+            personality,
+            id,
+            telegram
+        );
+        MatcherAssert.assertThat(
+            "Could not find resume",
+            resumes.resume(login).submitted(),
+            new IsEqual<>(time)
+        );
+    }
+
+    @Test
+    public void resumeHasText() throws Exception {
+        final Farm farm = new FkFarm();
+        final String login = "a-login";
+        final Instant time = Instant.parse("2018-01-01T00:00:00Z");
+        final String text = "Resume text";
+        final String personality = "ENTP-T";
+        final long id = 187141;
+        final String telegram = "telegram";
+        final Resumes resumes = new Resumes(farm).bootstrap();
+        resumes.add(
+            login,
+            LocalDateTime.ofInstant(time, ZoneOffset.UTC),
+            text,
+            personality,
+            id,
+            telegram
+        );
+        MatcherAssert.assertThat(
+            "Could not find resume",
+            resumes.resume(login).text(),
+            new IsEqual<>(text)
+        );
+    }
+
+    @Test
+    public void resumeHasPersonality() throws Exception {
+        final Farm farm = new FkFarm();
+        final String login = "a-login";
+        final Instant time = Instant.parse("2018-01-01T00:00:00Z");
+        final String text = "Resume text";
+        final String personality = "ENTP-T";
+        final long id = 187141;
+        final String telegram = "telegram";
+        final Resumes resumes = new Resumes(farm).bootstrap();
+        resumes.add(
+            login,
+            LocalDateTime.ofInstant(time, ZoneOffset.UTC),
+            text,
+            personality,
+            id,
+            telegram
+        );
+        MatcherAssert.assertThat(
+            "Could not find resume",
+            resumes.resume(login).personality(),
+            new IsEqual<>(personality)
+        );
+    }
+
+    @Test
+    public void resumeHasLoginStackOverflowId() throws Exception {
+        final Farm farm = new FkFarm();
+        final String login = "a-login";
+        final Instant time = Instant.parse("2018-01-01T00:00:00Z");
+        final String text = "Resume text";
+        final String personality = "ENTP-T";
+        final long id = 187141;
+        final String telegram = "telegram";
+        final Resumes resumes = new Resumes(farm).bootstrap();
+        resumes.add(
+            login,
+            LocalDateTime.ofInstant(time, ZoneOffset.UTC),
+            text,
+            personality,
+            id,
+            telegram
+        );
+        MatcherAssert.assertThat(
+            "Could not find resume",
+            resumes.resume(login).soid(),
+            new IsEqual<>(id)
+        );
+    }
+
+    @Test
+    public void resumeHasLoginTelegramId() throws Exception {
+        final Farm farm = new FkFarm();
+        final String login = "a-login";
+        final Instant time = Instant.parse("2018-01-01T00:00:00Z");
+        final String text = "Resume text";
+        final String personality = "ENTP-T";
+        final long id = 187141;
+        final String telegram = "atelegramid";
+        final Resumes resumes = new Resumes(farm).bootstrap();
+        resumes.add(
+            login,
+            LocalDateTime.ofInstant(time, ZoneOffset.UTC),
+            text,
+            personality,
+            id,
+            telegram
+        );
+        MatcherAssert.assertThat(
+            "Could not find resume",
+            resumes.resume(login).telegram(),
+            new IsEqual<>(telegram)
         );
     }
 }


### PR DESCRIPTION
This is for #1645

On top of solving the issue, I had to:
- adapt type of stackoverflow id used everywhere to `long` so that it matches with the type of `Resume.soid()`.
- change existing test and add some more
- increase the max class missed count to account for the unused `Resume.Fake`.