### PR TITLE
For #1824: Election when project has no funds and performer have no rate

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pm/staff/elections/elect_performer.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/staff/elections/elect_performer.groovy
@@ -99,7 +99,7 @@ def exec(Project project, XML xml) {
     ++count
     String role = wbs.role(job)
     List<String> allogins = roles.findByRole(role)
-    List<String> logins = new ArrayList<>()
+    List<String> logins = []
     if (deficit) {
       for (String login : allogins){
         if (!new Rates(project).bootstrap().exists(login)) {

--- a/src/main/groovy/com/zerocracy/stk/pm/staff/elections/elect_performer.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/staff/elections/elect_performer.groovy
@@ -88,7 +88,7 @@ def exec(Project project, XML xml) {
   int count = 0
   long vtime = System.nanoTime()
   String elected = 'not-elected'
-  boolean debt = new Ledger(farm, project).bootstrap().deficit()
+  boolean deficit = new Ledger(farm, project).bootstrap().deficit()
   for (String job : jobs) {
     if (orders.contains(job) || reviews.contains(job)) {
       continue
@@ -97,7 +97,7 @@ def exec(Project project, XML xml) {
     String role = wbs.role(job)
     List<String> allogins = roles.findByRole(role)
     List<String> logins = new ArrayList<>()
-    if (debt) {
+    if (deficit) {
       for (String login : allogins){
         if (!new Rates(project).bootstrap().exists(login)) {
           logins.add(login)

--- a/src/main/groovy/com/zerocracy/stk/pm/staff/elections/elect_performer.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/staff/elections/elect_performer.groovy
@@ -97,10 +97,14 @@ def exec(Project project, XML xml) {
     String role = wbs.role(job)
     List<String> allogins = roles.findByRole(role)
     List<String> logins = new ArrayList<>()
-    for (String login : allogins){
-      if (debt && !new Rates(project).bootstrap().exists(login)){
-        logins.add(login)
+    if (debt) {
+      for (String login : allogins){
+        if (!new Rates(project).bootstrap().exists(login)) {
+          logins.add(login)
+        }
       }
+    } else {
+      logins.addAll(allogins)
     }
     if (logins.empty) {
       return

--- a/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/_after.groovy
@@ -23,7 +23,7 @@ import org.hamcrest.MatcherAssert
 import org.hamcrest.core.IsEqual
 
 def exec(Project project, XML xml) {
-  String job = 'gh:test/test#1'
+  String job = 'gh:test/test#3'
   Orders orders = new Orders(farm, project).bootstrap()
   MatcherAssert.assertThat(
     'Performer was assigned to the job',

--- a/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/_after.groovy
@@ -17,12 +17,8 @@
 package com.zerocracy.bundles.elects_and_assigns_performer
 
 import com.jcabi.xml.XML
-import com.mongodb.client.model.Filters
-import com.zerocracy.Farm
 import com.zerocracy.Project
-import com.zerocracy.claims.Footprint
 import com.zerocracy.pm.in.Orders
-import org.cactoos.iterable.LengthOf
 import org.hamcrest.MatcherAssert
 import org.hamcrest.core.IsEqual
 

--- a/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/_after.groovy
@@ -14,7 +14,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.zerocracy.bundles.elects_and_assigns_performer
+package com.zerocracy.bundles.dont_elects_and_assigns_performer_when_debt
 
 import com.jcabi.xml.XML
 import com.zerocracy.Project

--- a/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/_after.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.elects_and_assigns_performer
+
+import com.jcabi.xml.XML
+import com.mongodb.client.model.Filters
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.claims.Footprint
+import com.zerocracy.pm.in.Orders
+import org.cactoos.iterable.LengthOf
+import org.hamcrest.MatcherAssert
+import org.hamcrest.core.IsEqual
+
+def exec(Project project, XML xml) {
+  String job = 'gh:test/test#1'
+  Orders orders = new Orders(farm, project).bootstrap()
+  MatcherAssert.assertThat(
+    'Performer was assigned to the job',
+    orders.assigned(job),
+    new IsEqual<>(false)
+  )
+}

--- a/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/_before.groovy
@@ -32,13 +32,6 @@ def exec(Project project, XML xml) {
   Github github = new ExtGithub(farm).value()
   Repo repo = github.repos().create(new Repos.RepoCreate('test', false))
   repo.issues().create('Hello, world', '')
-  new Ledger(farm, project).bootstrap().add(
-    new Ledger.Transaction(
-      new Cash.S('$1000'),
-      'expenses', 'jobs',
-      'liabilities', '@yegor256',
-      'Yegor is super expensive'
-    )
-  )
+  new Ledger(farm, project).bootstrap().deficit(true)
   new Rates(project).bootstrap().set('yegor256', new Cash.S('$10'))
 }

--- a/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/_before.groovy
@@ -31,7 +31,9 @@ def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
   Github github = new ExtGithub(farm).value()
   Repo repo = github.repos().create(new Repos.RepoCreate('test', false))
-  repo.issues().create('Hello, world', '')
+  repo.issues().create('Issue one', '')
+  repo.issues().create('Issue two', '')
+  repo.issues().create('Issue three', '')
   new Ledger(farm, project).bootstrap().deficit(true)
-  new Rates(project).bootstrap().set('yegor256', new Cash.S('$10'))
+  new Rates(project).bootstrap().set('paulodamaso', new Cash.S('$10'))
 }

--- a/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/_before.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.elects_and_assigns_performer
+
+import com.jcabi.github.Github
+import com.jcabi.github.Repo
+import com.jcabi.github.Repos
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.cash.Cash
+import com.zerocracy.entry.ExtGithub
+import com.zerocracy.pm.cost.Ledger
+import com.zerocracy.pm.cost.Rates
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  Github github = new ExtGithub(farm).value()
+  Repo repo = github.repos().create(new Repos.RepoCreate('test', false))
+  repo.issues().create('Hello, world', '')
+  new Ledger(farm, project).bootstrap().add(
+    new Ledger.Transaction(
+      new Cash.S('$1000'),
+      'expenses', 'jobs',
+      'liabilities', '@yegor256',
+      'Yegor is super expensive'
+    )
+  )
+  new Rates(project).bootstrap().set('yegor256', new Cash.S('$10'))
+}

--- a/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/_before.groovy
@@ -14,7 +14,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.zerocracy.bundles.elects_and_assigns_performer
+package com.zerocracy.bundles.dont_elects_and_assigns_performer_when_debt
 
 import com.jcabi.github.Github
 import com.jcabi.github.Repo

--- a/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/claims.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:32Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pm/claims.xsd">
+  <claim id="10">
+    <created>2017-03-27T11:18:09.228Z</created>
+    <type>ping</type>
+    <params>
+      <param name="force">yes</param>
+      <param name="reason">Need it</param>
+    </params>
+  </claim>
+</claims>

--- a/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/claims.xml
@@ -16,7 +16,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
 <claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:32Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pm/claims.xsd">
-  <claim id="10">
+  <claim id="20">
     <created>2017-03-27T11:18:09.228Z</created>
     <type>ping</type>
     <params>

--- a/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/people.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/people.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<people xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:29Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pmo/people.xsd">
+  <person id="yegor256">
+    <mentor>paulodamaso</mentor>
+    <reputation>0</reputation>
+    <projects>0</projects>
+    <jobs>0</jobs>
+    <skills updated="2018-02-22T18:35:15.684Z"/>
+    <applied>2018-01-01T00:00:00.000Z</applied>
+    <speed>0.0</speed>
+  </person>
+</people>

--- a/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/people.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/people.xml
@@ -16,8 +16,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
 <people xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:29Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pmo/people.xsd">
-  <person id="yegor256">
-    <mentor>paulodamaso</mentor>
+  <person id="paulodamaso">
+    <mentor>yegor256</mentor>
     <reputation>0</reputation>
     <projects>0</projects>
     <jobs>0</jobs>

--- a/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/roles.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/roles.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<roles xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:32Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pm/staff/roles.xsd">
+  <person id="yegor256">
+    <role>PO</role>
+    <role>ARC</role>
+    <role>DEV</role>
+  </person>
+  <person id="dmarkov">
+    <role>PO</role>
+  </person>
+</roles>

--- a/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/roles.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/roles.xml
@@ -16,12 +16,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
 <roles xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:32Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pm/staff/roles.xsd">
-  <person id="yegor256">
+  <person id="paulodamaso">
     <role>PO</role>
     <role>ARC</role>
     <role>DEV</role>
   </person>
-  <person id="dmarkov">
+  <person id="yegor256">
     <role>PO</role>
   </person>
 </roles>

--- a/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/wbs.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/wbs.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<wbs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:32Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pm/scope/wbs.xsd">
+  <job id="gh:test/test#1">
+    <created>2017-03-27T11:18:09.228Z</created>
+    <role>DEV</role>
+  </job>
+</wbs>

--- a/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/wbs.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_elects_and_assigns_performer_when_debt/wbs.xml
@@ -16,7 +16,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
 <wbs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:32Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pm/scope/wbs.xsd">
-  <job id="gh:test/test#1">
+  <job id="gh:test/test#3">
     <created>2017-03-27T11:18:09.228Z</created>
     <role>DEV</role>
   </job>

--- a/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer/_after.groovy
@@ -41,7 +41,8 @@ def exec(Project project, XML xml) {
       new Footprint(farm, project).collection().find(
         Filters.and(
           Filters.eq('project', project.pid()),
-          Filters.eq('type', 'Performer was elected')
+          Filters.eq('type', 'Performer was elected'),
+          Filters.eq('job', job)
         )
       )
     ).intValue(),

--- a/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/_after.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.elects_and_assigns_performer
+
+import com.jcabi.xml.XML
+import com.mongodb.client.model.Filters
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.claims.Footprint
+import com.zerocracy.pm.in.Orders
+import org.cactoos.iterable.LengthOf
+import org.hamcrest.MatcherAssert
+import org.hamcrest.core.IsEqual
+
+def exec(Project project, XML xml) {
+  String job = 'gh:test/test#1'
+  Orders orders = new Orders(farm, project).bootstrap()
+  MatcherAssert.assertThat(
+    'Performer wasn\'t assigned to the job',
+    orders.performer(job),
+    new IsEqual<>('yegor256')
+  )
+  Farm farm = binding.variables.farm
+  MatcherAssert.assertThat(
+    '"Performer was elected" claim was not found',
+    new LengthOf(
+      new Footprint(farm, project).collection().find(
+        Filters.and(
+          Filters.eq('project', project.pid()),
+          Filters.eq('type', 'Performer was elected')
+        )
+      )
+    ).intValue(),
+    new IsEqual<>(1)
+  )
+}

--- a/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/_after.groovy
@@ -27,21 +27,21 @@ import org.hamcrest.MatcherAssert
 import org.hamcrest.core.IsEqual
 
 def exec(Project project, XML xml) {
-  String job = 'gh:test/test#1'
+  String job = 'gh:test/test#2'
   Orders orders = new Orders(farm, project).bootstrap()
   MatcherAssert.assertThat(
     'Performer wasn\'t assigned to the job',
     orders.performer(job),
     new IsEqual<>('yegor256')
   )
-  Farm farm = binding.variables.farm
   MatcherAssert.assertThat(
     '"Performer was elected" claim was not found',
     new LengthOf(
       new Footprint(farm, project).collection().find(
         Filters.and(
           Filters.eq('project', project.pid()),
-          Filters.eq('type', 'Performer was elected')
+          Filters.eq('type', 'Performer was elected'),
+          Filters.eq('job', job)
         )
       )
     ).intValue(),

--- a/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/_after.groovy
@@ -14,7 +14,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.zerocracy.bundles.elects_and_assigns_performer
+package com.zerocracy.bundles.elects_and_assigns_performer_when_debt
 
 import com.jcabi.xml.XML
 import com.mongodb.client.model.Filters

--- a/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/_after.groovy
@@ -28,6 +28,7 @@ import org.hamcrest.core.IsEqual
 
 def exec(Project project, XML xml) {
   String job = 'gh:test/test#2'
+  Farm farm = binding.variables.farm
   Orders orders = new Orders(farm, project).bootstrap()
   MatcherAssert.assertThat(
     'Performer wasn\'t assigned to the job',

--- a/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/_before.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016-2018 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.elects_and_assigns_performer
+
+import com.jcabi.github.Github
+import com.jcabi.github.Repo
+import com.jcabi.github.Repos
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.cash.Cash
+import com.zerocracy.entry.ExtGithub
+import com.zerocracy.pm.cost.Ledger
+import com.zerocracy.pm.cost.Rates
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  Github github = new ExtGithub(farm).value()
+  Repo repo = github.repos().create(new Repos.RepoCreate('test', false))
+  repo.issues().create('Hello, world', '')
+  new Ledger(farm, project).bootstrap().add(
+    new Ledger.Transaction(
+      new Cash.S('$1000'),
+      'expenses', 'jobs',
+      'liabilities', '@yegor256',
+      'Yegor is super expensive'
+    )
+  )
+}

--- a/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/_before.groovy
@@ -22,22 +22,13 @@ import com.jcabi.github.Repos
 import com.jcabi.xml.XML
 import com.zerocracy.Farm
 import com.zerocracy.Project
-import com.zerocracy.cash.Cash
 import com.zerocracy.entry.ExtGithub
 import com.zerocracy.pm.cost.Ledger
-import com.zerocracy.pm.cost.Rates
 
 def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
   Github github = new ExtGithub(farm).value()
   Repo repo = github.repos().create(new Repos.RepoCreate('test', false))
   repo.issues().create('Hello, world', '')
-  new Ledger(farm, project).bootstrap().add(
-    new Ledger.Transaction(
-      new Cash.S('$1000'),
-      'expenses', 'jobs',
-      'liabilities', '@yegor256',
-      'Yegor is super expensive'
-    )
-  )
+  new Ledger(farm, project).bootstrap().deficit(true)
 }

--- a/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/_before.groovy
@@ -29,6 +29,7 @@ def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
   Github github = new ExtGithub(farm).value()
   Repo repo = github.repos().create(new Repos.RepoCreate('test', false))
-  repo.issues().create('Hello, world', '')
+  repo.issues().create('Issue one', '')
+  repo.issues().create('Issue two', '')
   new Ledger(farm, project).bootstrap().deficit(true)
 }

--- a/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/_before.groovy
@@ -14,7 +14,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.zerocracy.bundles.elects_and_assigns_performer
+package com.zerocracy.bundles.elects_and_assigns_performer_when_debt
 
 import com.jcabi.github.Github
 import com.jcabi.github.Repo

--- a/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/claims.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:32Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pm/claims.xsd">
+  <claim id="10">
+    <created>2017-03-27T11:18:09.228Z</created>
+    <type>ping</type>
+    <params>
+      <param name="force">yes</param>
+      <param name="reason">Need it</param>
+    </params>
+  </claim>
+</claims>

--- a/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/people.xml
+++ b/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/people.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<people xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:29Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pmo/people.xsd">
+  <person id="yegor256">
+    <mentor>paulodamaso</mentor>
+    <reputation>0</reputation>
+    <projects>0</projects>
+    <jobs>0</jobs>
+    <skills updated="2018-02-22T18:35:15.684Z"/>
+    <applied>2018-01-01T00:00:00.000Z</applied>
+    <speed>0.0</speed>
+  </person>
+</people>

--- a/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/roles.xml
+++ b/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/roles.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<roles xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:32Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pm/staff/roles.xsd">
+  <person id="yegor256">
+    <role>PO</role>
+    <role>ARC</role>
+    <role>DEV</role>
+  </person>
+  <person id="dmarkov">
+    <role>PO</role>
+  </person>
+</roles>

--- a/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/roles.xml
+++ b/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/roles.xml
@@ -21,7 +21,7 @@ SOFTWARE.
     <role>ARC</role>
     <role>DEV</role>
   </person>
-  <person id="dmarkov">
+  <person id="paulodamaso">
     <role>PO</role>
   </person>
 </roles>

--- a/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/wbs.xml
+++ b/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/wbs.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2018 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<wbs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:32Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pm/scope/wbs.xsd">
+  <job id="gh:test/test#1">
+    <created>2017-03-27T11:18:09.228Z</created>
+    <role>DEV</role>
+  </job>
+</wbs>

--- a/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/wbs.xml
+++ b/src/test/resources/com/zerocracy/bundles/elects_and_assigns_performer_when_debt/wbs.xml
@@ -16,7 +16,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
 <wbs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:32Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pm/scope/wbs.xsd">
-  <job id="gh:test/test#1">
+  <job id="gh:test/test#2">
     <created>2017-03-27T11:18:09.228Z</created>
     <role>DEV</role>
   </job>


### PR DESCRIPTION
For #1824:
- Corrected `elect_performer.groovy` to allow job assignment to performer with no rate set when project has no funds
- Added tests to test if 0crat is assigning jobs to users with no rates when project has no funds
- Added test to test if 0crat is not assigning job to user with rate when project has no funds