### PR TITLE
Allow pmo users to invite without resume

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pmo/profile/invite_friend.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pmo/profile/invite_friend.groovy
@@ -38,11 +38,8 @@ def exec(Project pmo, XML xml) {
   new Exam(farm, author).min('1.min-rep', 1024)
   String login = claim.param('login')
   Resumes resumes = new Resumes(farm).bootstrap()
-  // we allow to invite new students without limitations to PMO users
-  // and 'farm' (C3NDPUA8L) QA users
-  // see https://github.com/zerocracy/farm/issues/1410
   boolean force = new GlobalInviters(farm).contains(author)
-  if (!resumes.exists(login) || (resumes.examiner(login) != author && !force)) {
+  if ((!resumes.exists(login) || resumes.examiner(login) != author) && !force) {
     throw new SoftException(
       new Par(
         'You are not the examiner of %s or resume does not exist, see §1'

--- a/src/test/java/com/zerocracy/pm/staff/GlobalInvitersTest.java
+++ b/src/test/java/com/zerocracy/pm/staff/GlobalInvitersTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016-2019 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.pm.staff;
+
+import com.zerocracy.Farm;
+import com.zerocracy.farm.fake.FkFarm;
+import com.zerocracy.pmo.Pmo;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link GlobalInviters}.
+ *
+ * @since 1.0
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class GlobalInvitersTest {
+
+    @Test
+    public void containsPmoAndZerocracyQaPeople() throws Exception {
+        final Farm farm = new FkFarm();
+        final String pmouser = "pmouser";
+        final String zqa = "zerocracyqa";
+        new Roles(new Pmo(farm)).bootstrap().assign(pmouser, "DEV");
+        new Roles(farm.find("@id='C3NDPUA8L'").iterator().next())
+            .bootstrap()
+            .assign(zqa, "QA");
+        MatcherAssert.assertThat(
+            new GlobalInviters(farm),
+            Matchers.containsInAnyOrder(pmouser, zqa)
+        );
+    }
+}

--- a/src/test/resources/com/zerocracy/bundles/upO4js_examiner_can_invite/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/upO4js_examiner_can_invite/_after.groovy
@@ -42,6 +42,11 @@ def exec(Project project, XML xml) {
     new IsEqual<>(user)
   )
   MatcherAssert.assertThat(
+    'pmouser failed to invite',
+    people.mentor('pmofriend'),
+    new IsEqual<>('pmouser')
+  )
+  MatcherAssert.assertThat(
     'inviter didn\'t receive points',
     new Awards(farm, user).bootstrap().total(),
     new IsEqual<>(1266)

--- a/src/test/resources/com/zerocracy/bundles/upO4js_examiner_can_invite/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/upO4js_examiner_can_invite/_before.groovy
@@ -21,7 +21,9 @@ import com.jcabi.xml.XML
 import com.zerocracy.Farm
 import com.zerocracy.Project
 import com.zerocracy.entry.ExtGithub
+import com.zerocracy.pm.staff.Roles
 import com.zerocracy.pmo.Awards
+import com.zerocracy.pmo.Pmo
 import com.zerocracy.pmo.Resumes
 
 import java.time.LocalDateTime
@@ -46,4 +48,5 @@ def exec(Project project, XML xml) {
   new Awards(farm, 'other-user').bootstrap().add(
     project, 2048, 'gh:test/test#1', 'test'
   )
+  new Roles(new Pmo(farm)).bootstrap().assign('pmouser', 'DEV')
 }

--- a/src/test/resources/com/zerocracy/bundles/upO4js_examiner_can_invite/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/upO4js_examiner_can_invite/claims.xml
@@ -34,4 +34,13 @@ SOFTWARE.
     </params>
     <created>2018-07-24T01:00:00.000Z</created>
   </claim>
+  <claim id="100000">
+    <type>Invite a friend</type>
+    <token>test;C123;test</token>
+    <author>pmouser</author>
+    <params>
+      <param name="login">pmofriend</param>
+    </params>
+    <created>2018-07-24T01:00:00.000Z</created>
+  </claim>
 </claims>

--- a/src/test/resources/com/zerocracy/bundles/upO4js_examiner_can_invite/people.xml
+++ b/src/test/resources/com/zerocracy/bundles/upO4js_examiner_can_invite/people.xml
@@ -34,4 +34,13 @@ SOFTWARE.
     <applied>2018-01-01T00:00:00.000Z</applied>
     <speed>0.0</speed>
   </person>
+  <person id="pmouser">
+    <mentor>0crat</mentor>
+    <reputation>0</reputation>
+    <projects>0</projects>
+    <jobs>0</jobs>
+    <skills updated="2018-02-22T18:35:15.684Z"/>
+    <applied>2018-01-01T00:00:00.000Z</applied>
+    <speed>0.0</speed>
+  </person>
 </people>


### PR DESCRIPTION
#1948 - allow pmo users to invite without resume
#1905 - implemented `GlobalInviters` as PMO users and QA in Zerocracy project