### PR TITLE
New kpi metrics

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/internal/collect_daily_metrics.groovy
+++ b/src/main/groovy/com/zerocracy/stk/internal/collect_daily_metrics.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016-2019 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.stk.internal
+
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.farm.Assume
+import com.zerocracy.kpi.KpiMetrics
+import com.zerocracy.kpi.KpiOf
+import com.zerocracy.kpi.Metric
+import com.zerocracy.pmo.Catalog
+import com.zerocracy.pmo.People
+import org.cactoos.list.ListOf
+
+/**
+ * Collect KPI metrics.
+ *
+ * @param project Project
+ * @param xml Claim
+ */
+def exec(Project pmo, XML xml) {
+  new Assume(pmo, xml).type('Ping daily').isPmo()
+  Farm farm = binding.variables.farm
+  KpiMetrics kpi = new KpiOf(farm)
+  Catalog catalog = new Catalog(farm).bootstrap()
+  People people = new People(farm).bootstrap()
+  new ListOf<Metric>(
+    new Metric.S(
+      'active_projects', catalog.active().size()
+    ),
+    new Metric.S(
+      'active_users', people.active().size()
+    ),
+    new Metric.S(
+      'visible_users', people.visible().size()
+    ),
+    new Metric.S(
+      'total_reputation', people.totalReputation()
+    )
+  ).each { metric -> metric.send(kpi) }
+}

--- a/src/main/java/com/zerocracy/pmo/Catalog.java
+++ b/src/main/java/com/zerocracy/pmo/Catalog.java
@@ -942,6 +942,21 @@ public final class Catalog {
     }
 
     /**
+     * Active project IDs.
+     * @return Set of project IDs
+     * @throws IOException If fails
+     */
+    public Set<String> active() throws IOException {
+        try (final Item item = this.item()) {
+            return new HashSet<>(
+                new Xocument(item).xpath(
+                    "/catalog/project[alive = 'true']/@id"
+                )
+            );
+        }
+    }
+
+    /**
      * Check project exists, or throw exception.
      * @param pid Project id
      * @throws IOException If not exist

--- a/src/main/java/com/zerocracy/pmo/People.java
+++ b/src/main/java/com/zerocracy/pmo/People.java
@@ -28,7 +28,9 @@ import com.zerocracy.cash.Cash;
 import com.zerocracy.cash.CashParsingException;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Set;
 import org.cactoos.iterable.ItemAt;
 import org.cactoos.iterable.Joined;
 import org.cactoos.iterable.Mapped;
@@ -811,6 +813,52 @@ public final class People {
                         )
                     )
             );
+        }
+    }
+
+    /**
+     * Active users IDs (with reputation > 256).
+     * @return Active users IDs set
+     * @throws IOException If fails
+     */
+    public Set<String> active() throws IOException {
+        try (final Item item = this.item()) {
+            return new HashSet<>(
+                new Xocument(item).xpath(
+                    "/people/person[reputation > 256]/@id"
+                )
+            );
+        }
+    }
+
+    /**
+     * Visible users (with mentor and non-zero reputation).
+     * @return Visible users set
+     * @throws IOException If fails
+     */
+    public Set<String> visible() throws IOException {
+        try (final Item item = this.item()) {
+            return new HashSet<>(
+                new Xocument(item).xpath(
+                    "/people/person[mentor and reputation > 0]/@id"
+                )
+            );
+        }
+    }
+
+    /**
+     * Total reputation of all visible users.
+     * @return Reputation number
+     * @throws IOException If fails
+     */
+    public int totalReputation() throws IOException {
+        try (final Item item = this.item()) {
+            return new NumberOf(
+                new Xocument(item).xpath(
+                    "sum(/people/person[mentor and reputation >0]/reputation)",
+                    "0"
+                )
+            ).intValue();
         }
     }
 

--- a/src/test/java/com/zerocracy/pmo/CatalogTest.java
+++ b/src/test/java/com/zerocracy/pmo/CatalogTest.java
@@ -293,6 +293,19 @@ public final class CatalogTest {
         );
     }
 
+    @Test
+    public void collectsActive() throws Exception {
+        final Catalog catalog = new Catalog(new FkFarm()).bootstrap();
+        final String active = "AAAAAAAAA";
+        catalog.add(active, "2018/10/000000401/");
+        final String inactive = "IIIIIIIII";
+        catalog.add(inactive, "2018/10/000000402/");
+        catalog.pause(inactive, true);
+        MatcherAssert.assertThat(
+            catalog.active(), Matchers.contains(active)
+        );
+    }
+
     private static Catalog withProject(final String pid) throws IOException {
         final Pmo pmo = new Pmo(new FkFarm());
         final Catalog catalog = new Catalog(pmo).bootstrap();

--- a/src/test/java/com/zerocracy/pmo/PeopleTest.java
+++ b/src/test/java/com/zerocracy/pmo/PeopleTest.java
@@ -45,6 +45,7 @@ import org.junit.rules.ExpectedException;
  * @since 1.0
  * @checkstyle JavadocMethodCheck (1000 lines)
  * @checkstyle JavadocVariableCheck (1000 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (3 lines)
  */
 @SuppressWarnings(
@@ -501,6 +502,46 @@ public final class PeopleTest {
         MatcherAssert.assertThat(
             people.skills(uid),
             Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    public void collectsActive() throws Exception {
+        final People people = new People(new FkFarm()).bootstrap();
+        final String active = "active";
+        people.invite(active, "0crat");
+        people.reputation(active, 257);
+        final String inactive = "inactive";
+        people.invite(inactive, "0crat");
+        people.reputation(inactive, 255);
+        MatcherAssert.assertThat(
+            people.active(), Matchers.contains(active)
+        );
+    }
+
+    @Test
+    public void collectsVisible() throws Exception {
+        final People people = new People(new FkFarm()).bootstrap();
+        final String visible = "visible";
+        people.invite(visible, "0crat");
+        people.reputation(visible, 1);
+        people.invite("empty", "0crat");
+        people.touch("nomentor");
+        MatcherAssert.assertThat(
+            people.visible(), Matchers.contains(visible)
+        );
+    }
+
+    @Test
+    public void totalReputation() throws Exception {
+        final People people = new People(new FkFarm()).bootstrap();
+        for (int num = 0; num < 10; ++num) {
+            final String login = String.format("user%d", num);
+            people.invite(login, "0crat");
+            people.reputation(login, num);
+        }
+        MatcherAssert.assertThat(
+            people.totalReputation(), Matchers.equalTo(45)
         );
     }
 }


### PR DESCRIPTION
#2036 #2035 - new kpi metrics every day:
 - `active_projects` - amount of active projects (not on pause)
 - `active_users` - amount of users with reputation > 256
 - `visible_users` - amount of users with mentor and reputation > 0
 - `total_reputation` - total reputation of all visible users