### PR TITLE
#2018: Notify performer on wait/continue

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pm/in/impediments/add_waiting_label.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/in/impediments/add_waiting_label.groovy
@@ -29,7 +29,6 @@ import com.zerocracy.entry.ClaimsOf
 import com.zerocracy.entry.ExtGithub
 import com.zerocracy.farm.Assume
 import com.zerocracy.pm.in.Orders
-import com.zerocracy.pmo.People
 import com.zerocracy.radars.github.Job
 
 def exec(Project project, XML xml) {
@@ -45,23 +44,20 @@ def exec(Project project, XML xml) {
   Github github = new ExtGithub(farm).value()
   Issue.Smart issue = new Issue.Smart(new Job.Issue(github, job))
   try {
-    Boolean added = new IssueLabels.Smart(issue.labels()).addIfAbsent('waiting', 'eafc64')
-    if (added && orders.assigned(job)) {
+    new IssueLabels.Smart(issue.labels()).addIfAbsent('waiting', 'eafc64')
+    if (orders.assigned(job)) {
       String login = orders.performer(job)
-      new People(farm).bootstrap().links(login, 'telegram').any { uid ->
-        claim.copy()
-              .type('Notify in Telegram')
-              .token("telegram;${uid}")
-              .param('login', login)
-              .param(
-                'message',
-                new Par(
-                        farm,
-                        'The job %s in %s is in WAIT status'
-                ).say(job, project.pid())
-              )
-              .postTo(new ClaimsOf(farm, project))
-      }
+      claim.copy()
+        .type('Notify user')
+        .token("user;${login}")
+        .param(
+          'message',
+          new Par(
+            farm,
+            'The job %s in %s is in WAIT status'
+          ).say(job, project.pid())
+        )
+        .postTo(new ClaimsOf(farm, project))
     }
   } catch (AssertionError ex) {
     Logger.warn(this, "Can't add label to issue %s: %s", issue, ex.localizedMessage)

--- a/src/main/groovy/com/zerocracy/stk/pm/in/impediments/add_waiting_label.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/in/impediments/add_waiting_label.groovy
@@ -22,10 +22,14 @@ import com.jcabi.github.IssueLabels
 import com.jcabi.log.Logger
 import com.jcabi.xml.XML
 import com.zerocracy.Farm
+import com.zerocracy.Par
 import com.zerocracy.Project
 import com.zerocracy.claims.ClaimIn
+import com.zerocracy.entry.ClaimsOf
 import com.zerocracy.entry.ExtGithub
 import com.zerocracy.farm.Assume
+import com.zerocracy.pm.in.Orders
+import com.zerocracy.pmo.People
 import com.zerocracy.radars.github.Job
 
 def exec(Project project, XML xml) {
@@ -37,10 +41,28 @@ def exec(Project project, XML xml) {
     return
   }
   Farm farm = binding.variables.farm
+  Orders orders = new Orders(farm, project).bootstrap()
   Github github = new ExtGithub(farm).value()
   Issue.Smart issue = new Issue.Smart(new Job.Issue(github, job))
   try {
-    new IssueLabels.Smart(issue.labels()).addIfAbsent('waiting', 'eafc64')
+    Boolean added = new IssueLabels.Smart(issue.labels()).addIfAbsent('waiting', 'eafc64')
+    if (added && orders.assigned(job)) {
+      String login = orders.performer(job)
+      new People(farm).bootstrap().links(login, 'telegram').any { uid ->
+        claim.copy()
+              .type('Notify in Telegram')
+              .token("telegram;${uid}")
+              .param('login', login)
+              .param(
+                'message',
+                new Par(
+                        farm,
+                        'The job %s in %s is in WAIT status'
+                ).say(job, project.pid())
+              )
+              .postTo(new ClaimsOf(farm, project))
+      }
+    }
   } catch (AssertionError ex) {
     Logger.warn(this, "Can't add label to issue %s: %s", issue, ex.localizedMessage)
   }

--- a/src/main/groovy/com/zerocracy/stk/pm/in/impediments/remove_waiting_label.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/in/impediments/remove_waiting_label.groovy
@@ -22,10 +22,14 @@ import com.jcabi.github.IssueLabels
 import com.jcabi.log.Logger
 import com.jcabi.xml.XML
 import com.zerocracy.Farm
+import com.zerocracy.Par
 import com.zerocracy.Project
 import com.zerocracy.claims.ClaimIn
+import com.zerocracy.entry.ClaimsOf
 import com.zerocracy.entry.ExtGithub
 import com.zerocracy.farm.Assume
+import com.zerocracy.pm.in.Orders
+import com.zerocracy.pmo.People
 import com.zerocracy.radars.github.Job
 
 def exec(Project project, XML xml) {
@@ -37,10 +41,28 @@ def exec(Project project, XML xml) {
     return
   }
   Farm farm = binding.variables.farm
+  Orders orders = new Orders(farm, project).bootstrap()
   Github github = new ExtGithub(farm).value()
   Issue.Smart issue = new Issue.Smart(new Job.Issue(github, job))
   try {
-    new IssueLabels.Smart(issue.labels()).removeIfExists('waiting')
+    Boolean removed = new IssueLabels.Smart(issue.labels()).removeIfExists('waiting')
+    if (removed && orders.assigned(job)) {
+      String login = orders.performer(job)
+      new People(farm).bootstrap().links(login, 'telegram').any { uid ->
+        claim.copy()
+          .type('Notify in Telegram')
+          .token("telegram;${uid}")
+          .param('login', login)
+          .param(
+      'message',
+            new Par(
+              farm,
+        'The job %s in %s is in CONTINUE status'
+            ).say(job, project.pid())
+          )
+          .postTo(new ClaimsOf(farm, project))
+      }
+    }
   } catch (AssertionError ex) {
     Logger.warn(this, "Can't add label to issue %s: %s", issue, ex.localizedMessage)
   }

--- a/src/main/groovy/com/zerocracy/stk/pm/in/impediments/remove_waiting_label.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/in/impediments/remove_waiting_label.groovy
@@ -29,7 +29,6 @@ import com.zerocracy.entry.ClaimsOf
 import com.zerocracy.entry.ExtGithub
 import com.zerocracy.farm.Assume
 import com.zerocracy.pm.in.Orders
-import com.zerocracy.pmo.People
 import com.zerocracy.radars.github.Job
 
 def exec(Project project, XML xml) {
@@ -45,23 +44,20 @@ def exec(Project project, XML xml) {
   Github github = new ExtGithub(farm).value()
   Issue.Smart issue = new Issue.Smart(new Job.Issue(github, job))
   try {
-    Boolean removed = new IssueLabels.Smart(issue.labels()).removeIfExists('waiting')
-    if (removed && orders.assigned(job)) {
+    new IssueLabels.Smart(issue.labels()).removeIfExists('waiting')
+    if (orders.assigned(job)) {
       String login = orders.performer(job)
-      new People(farm).bootstrap().links(login, 'telegram').any { uid ->
-        claim.copy()
-          .type('Notify in Telegram')
-          .token("telegram;${uid}")
-          .param('login', login)
-          .param(
-      'message',
-            new Par(
-              farm,
-        'The job %s in %s is in CONTINUE status'
-            ).say(job, project.pid())
-          )
-          .postTo(new ClaimsOf(farm, project))
-      }
+      claim.copy()
+      .type('Notify user')
+      .token("user;${login}")
+      .param(
+        'message',
+        new Par(
+          farm,
+          'The job %s in %s is in CONTINUE status'
+        ).say(job, project.pid())
+      )
+      .postTo(new ClaimsOf(farm, project))
     }
   } catch (AssertionError ex) {
     Logger.warn(this, "Can't add label to issue %s: %s", issue, ex.localizedMessage)

--- a/src/test/resources/com/zerocracy/bundles/upq0fy_adds_waiting_label_to_issue/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/upq0fy_adds_waiting_label_to_issue/_after.groovy
@@ -20,12 +20,16 @@ import com.jcabi.github.Github
 import com.jcabi.github.Issue
 import com.jcabi.github.IssueLabels
 import com.jcabi.xml.XML
+import com.mongodb.client.model.Filters
 import com.zerocracy.Farm
 import com.zerocracy.Project
+import com.zerocracy.claims.Footprint
 import com.zerocracy.entry.ExtGithub
 import com.zerocracy.radars.github.Job
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
+import org.hamcrest.collection.IsEmptyIterable
+import org.hamcrest.core.IsNot
 
 def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
@@ -35,4 +39,17 @@ def exec(Project project, XML xml) {
     new IssueLabels.Smart(new Issue.Smart(new Job.Issue(github, 'gh:test/test#1')).labels()).contains('waiting'),
     Matchers.is(true)
   )
+  new Footprint(farm, project).withCloseable { Footprint footprint ->
+    MatcherAssert.assertThat(
+ 'Performer not notified',
+        footprint.collection().find(
+            Filters.and(
+                Filters.eq('project', project.pid()),
+                Filters.eq('type', 'Notify in Telegram'),
+                Filters.eq('token', 'telegram;463943472')
+            )
+        ),
+        new IsNot(new IsEmptyIterable<>())
+    )
+  }
 }

--- a/src/test/resources/com/zerocracy/bundles/upq0fy_adds_waiting_label_to_issue/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/upq0fy_adds_waiting_label_to_issue/_after.groovy
@@ -20,16 +20,12 @@ import com.jcabi.github.Github
 import com.jcabi.github.Issue
 import com.jcabi.github.IssueLabels
 import com.jcabi.xml.XML
-import com.mongodb.client.model.Filters
 import com.zerocracy.Farm
 import com.zerocracy.Project
-import com.zerocracy.claims.Footprint
 import com.zerocracy.entry.ExtGithub
 import com.zerocracy.radars.github.Job
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
-import org.hamcrest.collection.IsEmptyIterable
-import org.hamcrest.core.IsNot
 
 def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
@@ -39,17 +35,4 @@ def exec(Project project, XML xml) {
     new IssueLabels.Smart(new Issue.Smart(new Job.Issue(github, 'gh:test/test#1')).labels()).contains('waiting'),
     Matchers.is(true)
   )
-  new Footprint(farm, project).withCloseable { Footprint footprint ->
-    MatcherAssert.assertThat(
- 'Performer not notified',
-        footprint.collection().find(
-            Filters.and(
-                Filters.eq('project', project.pid()),
-                Filters.eq('type', 'Notify in Telegram'),
-                Filters.eq('token', 'telegram;463943472')
-            )
-        ),
-        new IsNot(new IsEmptyIterable<>())
-    )
-  }
 }

--- a/src/test/resources/com/zerocracy/bundles/upq0fy_adds_waiting_label_to_issue/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/upq0fy_adds_waiting_label_to_issue/_before.groovy
@@ -24,7 +24,6 @@ import com.jcabi.xml.XML
 import com.zerocracy.Farm
 import com.zerocracy.Project
 import com.zerocracy.entry.ExtGithub
-import com.zerocracy.pmo.People
 
 def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm

--- a/src/test/resources/com/zerocracy/bundles/upq0fy_adds_waiting_label_to_issue/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/upq0fy_adds_waiting_label_to_issue/_before.groovy
@@ -45,17 +45,17 @@ def exec(Project project, XML xml) {
   TmZerocrat tmZerocrat = Mockito.mock(TmZerocrat)
   Mockito.when(mockedFunc.apply(Mockito.any(ExtTelegram))).thenReturn(tmZerocrat)
   Mockito.doNothing().when(tmZerocrat).post(Mockito.any(SendMessage))
-  Field field = ExtTelegram.class.getDeclaredField("SINGLETON")
+  Field field = ExtTelegram.getDeclaredField('SINGLETON')
 
   setFinalStatic(field, mockedFunc)
 }
 
 static setFinalStatic(Field field, Object newValue) {
   field.setAccessible(true)
-  Field modifiersField = Field.class.getDeclaredField("modifiers")
+  Field modifiersField = Field.getDeclaredField('modifiers')
   modifiersField.setAccessible(true)
   Modifier.FINAL
-  modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL)
+  modifiersField.setInt(field, field.modifiers & ~Modifier.FINAL)
   field.set(null, newValue)
 }
 

--- a/src/test/resources/com/zerocracy/bundles/upq0fy_adds_waiting_label_to_issue/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/upq0fy_adds_waiting_label_to_issue/_before.groovy
@@ -24,14 +24,7 @@ import com.jcabi.xml.XML
 import com.zerocracy.Farm
 import com.zerocracy.Project
 import com.zerocracy.entry.ExtGithub
-import com.zerocracy.entry.ExtTelegram
 import com.zerocracy.pmo.People
-import com.zerocracy.radars.telegram.TmZerocrat
-import org.cactoos.func.UncheckedFunc
-import org.mockito.Mockito
-import org.telegram.telegrambots.api.methods.send.SendMessage
-import java.lang.reflect.Field
-import java.lang.reflect.Modifier
 
 def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm
@@ -39,23 +32,5 @@ def exec(Project project, XML xml) {
   Repo repo = github.repos().create(new Repos.RepoCreate('test', false))
   Issue issue = new Issue.Smart(repo.issues().create('The issue', 'to wait'))
   issue.assign('yegor256')
-  new People(farm).bootstrap().link('yegor256', 'telegram', '463943472')
-
-  UncheckedFunc mockedFunc =  Mockito.mock(UncheckedFunc)
-  TmZerocrat tmZerocrat = Mockito.mock(TmZerocrat)
-  Mockito.when(mockedFunc.apply(Mockito.any(ExtTelegram))).thenReturn(tmZerocrat)
-  Mockito.doNothing().when(tmZerocrat).post(Mockito.any(SendMessage))
-  Field field = ExtTelegram.getDeclaredField('SINGLETON')
-
-  setFinalStatic(field, mockedFunc)
-}
-
-static setFinalStatic(Field field, Object newValue) {
-  field.setAccessible(true)
-  Field modifiersField = Field.getDeclaredField('modifiers')
-  modifiersField.setAccessible(true)
-  Modifier.FINAL
-  modifiersField.setInt(field, field.modifiers & ~Modifier.FINAL)
-  field.set(null, newValue)
 }
 

--- a/src/test/resources/com/zerocracy/bundles/upq0fy_adds_waiting_label_to_issue/orders.xml
+++ b/src/test/resources/com/zerocracy/bundles/upq0fy_adds_waiting_label_to_issue/orders.xml
@@ -17,7 +17,7 @@ SOFTWARE.
 -->
 <orders xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:33Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pm/in/orders.xsd">
   <order job="gh:test/test#1">
-    <created>2017-03-27T11:18:09.228Z</created>
+    <created>2018-03-27T11:18:09.228Z</created>
     <performer>yegor256</performer>
     <reason>some reason</reason>
   </order>


### PR DESCRIPTION
https://github.com/zerocracy/farm/issues/2018
Please note that Reflection is used in BundleTest to mock ExtTelegram.SINGLETON. 