### PR TITLE
No double period on project page for ousiders

### DIFF
--- a/src/main/resources/xsl/project.xsl
+++ b/src/main/resources/xsl/project.xsl
@@ -132,7 +132,6 @@ SOFTWARE.
           <a href="http://www.zerocracy.com/policy.html#2">
             <xsl:text>apply</xsl:text>
           </a>
-          <xsl:text>.</xsl:text>
         </xsl:otherwise>
       </xsl:choose>
       <xsl:if test="vesting">


### PR DESCRIPTION
When I open a project page I see this:

<img width="483" alt="image" src="https://user-images.githubusercontent.com/252023/59113987-4556fe80-8957-11e9-9688-8c232901b779.png">

The double period at the end bugs me. It's there in the source:

```html
<p>You are not working in this project, but you can <a href="http://www.zerocracy.com/policy.html#2">apply</a>..
</p>
```

I've removed it. The main closing period of this sentence is further down the XSL, after vesting information.