### PR TITLE
Improve formatting of task notification for developer

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pm/in/orders/notify_user_on_order.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/in/orders/notify_user_on_order.groovy
@@ -32,13 +32,13 @@ def exec(Project project, XML xml) {
   String job = claim.param('job')
   String role = claim.param('role')
   Estimates estimates = new Estimates(farm, project).bootstrap()
-  String tail
+  String reward
   if (estimates.exists(job)) {
-    tail = new Par(
+    reward = new Par(
       'you will earn %s on completion'
     ).say(estimates.get(job))
   } else {
-    tail = new Par('you won\'t earn any cash on completion').say()
+    reward = new Par('you won\'t earn any cash on completion').say()
   }
   Farm farm = binding.variables.farm
   claim.copy()
@@ -50,7 +50,7 @@ def exec(Project project, XML xml) {
         farm,
         'The job %s was assigned to you in %s as %s a minute ago;',
         'here is [why](/footprint/%2$s/%s); '
-      ).say(job, project.pid(), role, claim.param('reason')) + tail
+      ).say(job, project.pid(), role, claim.param('reason')) + reward
     )
     .postTo(new ClaimsOf(farm, project))
 }

--- a/src/main/groovy/com/zerocracy/stk/pm/in/orders/notify_user_on_order.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/in/orders/notify_user_on_order.groovy
@@ -49,7 +49,7 @@ def exec(Project project, XML xml) {
       new Par(
         farm,
         'The job %s was assigned to you in %s as %s a minute ago;',
-        'here is [why](/footprint/%2$s/%s);'
+        'here is [why](/footprint/%2$s/%s); '
       ).say(job, project.pid(), role, claim.param('reason')) + tail
     )
     .postTo(new ClaimsOf(farm, project))


### PR DESCRIPTION
I receive task notifications:

![image](https://user-images.githubusercontent.com/252023/60130103-9e23f500-97a7-11e9-8fe4-a3ca02c37388.png)

There is no space between "why" and "you".

I believe now there will be.

I also improved the name of the variable.