### PR TITLE
New maxRevJobsInAgenda option

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pm/staff/elections/elect_performer.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/staff/elections/elect_performer.groovy
@@ -125,7 +125,7 @@ def exec(Project project, XML xml) {
           (wrapped(new VsBigDebt(pmo)))                                          : -100,
           (wrapped(new VsNoRoom(pmo)))                                           : role == 'REV' ? 0 : -100,
           (wrapped(new VsOptionsMaxJobs(pmo)))                                   : role == 'REV' ? 0 : -100,
-          (wrapped(new VsOptionsMaxRevJobs(pmo)))                                : -100,
+          (wrapped(new VsOptionsMaxRevJobs(pmo)))                                : role == 'REV' ? -100 : 0,
           (wrapped(new VsBanned(project, job)))                                  : -100,
           (wrapped(new VsVacation(pmo)))                                         : -100,
           (wrapped(new VsWorkload(farm, logins)))                                : 1,

--- a/src/main/groovy/com/zerocracy/stk/pm/staff/elections/elect_performer.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/staff/elections/elect_performer.groovy
@@ -125,6 +125,7 @@ def exec(Project project, XML xml) {
           (wrapped(new VsBigDebt(pmo)))                                          : -100,
           (wrapped(new VsNoRoom(pmo)))                                           : role == 'REV' ? 0 : -100,
           (wrapped(new VsOptionsMaxJobs(pmo)))                                   : role == 'REV' ? 0 : -100,
+          (wrapped(new VsOptionsMaxRevJobs(pmo)))                                : -100,
           (wrapped(new VsBanned(project, job)))                                  : -100,
           (wrapped(new VsVacation(pmo)))                                         : -100,
           (wrapped(new VsWorkload(farm, logins)))                                : 1,

--- a/src/main/java/com/zerocracy/Xocument.java
+++ b/src/main/java/com/zerocracy/Xocument.java
@@ -74,7 +74,7 @@ public final class Xocument {
     /**
      * Current DATUM version.
      */
-    public static final String VERSION = "0.65.2";
+    public static final String VERSION = "0.66.1";
 
     /**
      * Cache of documents.

--- a/src/main/java/com/zerocracy/pm/staff/votes/VsOptionsMaxRevJobs.java
+++ b/src/main/java/com/zerocracy/pm/staff/votes/VsOptionsMaxRevJobs.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2016-2019 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.pm.staff.votes;
+
+import com.zerocracy.pm.staff.Votes;
+import com.zerocracy.pmo.Agenda;
+import com.zerocracy.pmo.Options;
+import com.zerocracy.pmo.Pmo;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import org.cactoos.text.UncheckedText;
+
+/**
+ * Voter that prohibits more than maxRevJobsInAgenda for given user.
+ *
+ * @since 1.0
+ */
+public final class VsOptionsMaxRevJobs implements Votes {
+
+    /**
+     * The PMO.
+     */
+    private final Pmo pmo;
+
+    /**
+     * Ctor.
+     * @param pkt Current project
+     */
+    public VsOptionsMaxRevJobs(final Pmo pkt) {
+        this.pmo = pkt;
+    }
+
+    @Override
+    public double take(final String login, final StringBuilder log)
+        throws IOException {
+        final int total = revJobs(
+            new Agenda(this.pmo, login).bootstrap()
+        ).size();
+        final double rate;
+        final int max = new Options(this.pmo, login).bootstrap()
+            .maxRevJobsInAgenda();
+        if (total >= max) {
+            rate = 1.0d;
+            log.append(
+                String.format(
+                    "%d REV job(s) already, maxRevJobsInAgenda option is %d",
+                    total, max
+                )
+            );
+        } else {
+            rate = 0.0d;
+            log.append(
+                String.format(
+                    "%d REV job(s) out of %d from maxRevJobsInAgenda option",
+                    total, max
+                )
+            );
+        }
+        return rate;
+    }
+
+    private Collection<String> revJobs(Agenda agenda) throws IOException {
+        return agenda.jobs().stream().filter(
+            job -> "REV".equals(
+                new UncheckedText(() -> agenda.role(job)).asString()
+            )
+        ).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/zerocracy/pm/staff/votes/VsOptionsMaxRevJobs.java
+++ b/src/main/java/com/zerocracy/pm/staff/votes/VsOptionsMaxRevJobs.java
@@ -48,7 +48,7 @@ public final class VsOptionsMaxRevJobs implements Votes {
     @Override
     public double take(final String login, final StringBuilder log)
         throws IOException {
-        final int total = revJobs(
+        final int total = VsOptionsMaxRevJobs.revJobs(
             new Agenda(this.pmo, login).bootstrap()
         ).size();
         final double rate;
@@ -74,7 +74,15 @@ public final class VsOptionsMaxRevJobs implements Votes {
         return rate;
     }
 
-    private Collection<String> revJobs(Agenda agenda) throws IOException {
+    /**
+     * All REV jobs in agenda.
+     * @param agenda The agenda.
+     * @return All REV jobs in agenda.
+     * @throws IOException If something fails.
+     */
+    private static Collection<String> revJobs(
+        final Agenda agenda
+    ) throws IOException {
         return agenda.jobs().stream().filter(
             job -> "REV".equals(
                 new UncheckedText(() -> agenda.role(job)).asString()

--- a/src/main/java/com/zerocracy/pmo/Agenda.java
+++ b/src/main/java/com/zerocracy/pmo/Agenda.java
@@ -390,6 +390,30 @@ public final class Agenda {
     }
 
     /**
+     * Retrieves the role of the specified job.
+     * @param job The job whose role is to be retrieved.
+     * @return The role of the job.
+     * @throws IOException If fails.
+     */
+    public String role(final String job) throws IOException {
+        if (!this.exists(job)) {
+            throw new SoftException(
+                new Par(
+                    "Job %s is not in the agenda of @%s, can't retrieve role"
+                ).say(job, this.login)
+            );
+        }
+        try (final Item item = this.item()) {
+            return new Xocument(item.path()).nodes(
+                String.format(
+                    "/agenda/order[@job='%s']/role",
+                    job
+                )
+            ).get(0).node().getTextContent();
+        }
+    }
+
+    /**
      * The item.
      * @return Item
      * @throws IOException If fails

--- a/src/main/java/com/zerocracy/pmo/Options.java
+++ b/src/main/java/com/zerocracy/pmo/Options.java
@@ -98,6 +98,42 @@ public final class Options {
     }
 
     /**
+     * Max REV jobs in agenda.
+     * @return REV jobs number
+     * @throws IOException If fails
+     */
+    public int maxRevJobsInAgenda() throws IOException {
+        try (final Item item = this.item()) {
+            return new IoCheckedScalar<>(
+                new ItemAt<Number>(
+                    xpath -> Integer.MAX_VALUE,
+                    new Mapped<>(
+                        NumberOf::new,
+                        new Xocument(item.path())
+                            .xpath("/options/maxRevJobsInAgenda/text()")
+                    )
+                )
+            ).value().intValue();
+        }
+    }
+
+    /**
+     * Set max REV jobs in agenda.
+     * @param max Max REV jobs in agenda
+     * @throws IOException If fails
+     */
+    public void maxRevJobsInAgenda(final int max) throws IOException {
+        try (final Item item = this.item()) {
+            new Xocument(item.path()).modify(
+                new Directives()
+                    .xpath("/options")
+                    .addIf("maxRevJobsInAgenda")
+                    .set(max)
+            );
+        }
+    }
+
+    /**
      * Notify students option.
      * @return True if set
      * @throws IOException If fails

--- a/src/main/java/com/zerocracy/pmo/Options.java
+++ b/src/main/java/com/zerocracy/pmo/Options.java
@@ -86,6 +86,7 @@ public final class Options {
      * @param max Max jobs in agenda
      * @throws IOException If fails
      */
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     public void maxJobsInAgenda(final int max) throws IOException {
         try (final Item item = this.item()) {
             new Xocument(item.path()).modify(
@@ -122,6 +123,7 @@ public final class Options {
      * @param max Max REV jobs in agenda
      * @throws IOException If fails
      */
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     public void maxRevJobsInAgenda(final int max) throws IOException {
         try (final Item item = this.item()) {
             new Xocument(item.path()).modify(

--- a/src/test/java/com/zerocracy/pm/staff/votes/VsOptionsMaxRevJobsTest.java
+++ b/src/test/java/com/zerocracy/pm/staff/votes/VsOptionsMaxRevJobsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2016-2019 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.pm.staff.votes;
+
+import com.zerocracy.Project;
+import com.zerocracy.farm.fake.FkFarm;
+import com.zerocracy.farm.fake.FkProject;
+import com.zerocracy.pmo.Agenda;
+import com.zerocracy.pmo.Options;
+import com.zerocracy.pmo.Pmo;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link VsOptionsMaxRevJobs}.
+ *
+ * @since 1.0
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class VsOptionsMaxRevJobsTest {
+
+    @Test
+    public void votesHighIfMaxRevJobsReached() throws Exception {
+        final Project project = new FkProject();
+        final String user = "g4s8";
+        final int total = 10;
+        final Pmo pmo = new Pmo(new FkFarm());
+        new Options(pmo, user).bootstrap().maxRevJobsInAgenda(total);
+        final Agenda agenda = new Agenda(pmo, user).bootstrap();
+        for (int num = 0; num < total; ++num) {
+            agenda.add(project, String.format("gh:test/test#%d", num), "REV");
+        }
+        MatcherAssert.assertThat(
+            new VsOptionsMaxRevJobs(pmo).take(user, new StringBuilder(0)),
+            // @checkstyle MagicNumberCheck (1 lines)
+            Matchers.closeTo(1.0, 0.001)
+        );
+    }
+
+    @Test
+    public void votesLowHasRoom() throws Exception {
+        final String user = "krzyk";
+        final Pmo pmo = new Pmo(new FkFarm());
+        new Options(pmo, user).bootstrap().maxRevJobsInAgenda(1);
+        MatcherAssert.assertThat(
+            new VsOptionsMaxRevJobs(pmo).take(user, new StringBuilder(0)),
+            // @checkstyle MagicNumberCheck (1 lines)
+            Matchers.closeTo(0.0, 0.001)
+        );
+    }
+}

--- a/src/test/java/com/zerocracy/pmo/AgendaTest.java
+++ b/src/test/java/com/zerocracy/pmo/AgendaTest.java
@@ -18,6 +18,7 @@ package com.zerocracy.pmo;
 
 import com.jcabi.aspects.Tv;
 import com.jcabi.matchers.XhtmlMatchers;
+import com.zerocracy.Farm;
 import com.zerocracy.Project;
 import com.zerocracy.SoftException;
 import com.zerocracy.Xocument;
@@ -199,6 +200,23 @@ public final class AgendaTest {
         agenda.add(project, first, "REV");
         MatcherAssert.assertThat(
             agenda.added(first), Matchers.is(time)
+        );
+    }
+
+    @Test
+    public void returnsRole() throws Exception {
+        final Project project = new FkProject();
+        final Farm farm = new FkFarm(project);
+        final Agenda agenda = new Agenda(farm, "yegor").bootstrap();
+        final String dev = "gh:test/test#1";
+        agenda.add(project, dev, "DEV");
+        MatcherAssert.assertThat(
+            agenda.role(dev), Matchers.is("DEV")
+        );
+        final String rev = "gh:test/test#2";
+        agenda.add(project, rev, "REV");
+        MatcherAssert.assertThat(
+            agenda.role(rev), Matchers.is("REV")
         );
     }
 }


### PR DESCRIPTION
PR for https://github.com/zerocracy/farm/issues/1906.

- Added a `maxRevJobsInAgenda` option to control max REV jobs in agenda. This includes a new `VsOptionsMaxRevJobs` rule and accessor+mutator in `Options` for the new option.
- Added a `String role(job)` method in `Agenda` to determine the role of a job. This was necessary for the `VsOptionsMaxRevJobs` to be able to count REV jobs in the `Agenda`.
- Updated `Xocument`'s version to enable validations against updated XSD in Datum.