### PR TITLE
For #2237: Dont kickout graduates from sandbox projects

### DIFF
--- a/src/main/groovy/com/zerocracy/stk/pm/staff/roles/kickout_from_sandbox.groovy
+++ b/src/main/groovy/com/zerocracy/stk/pm/staff/roles/kickout_from_sandbox.groovy
@@ -30,6 +30,12 @@ import com.zerocracy.pmo.Catalog
 import com.zerocracy.pmo.People
 
 def exec(Project project, XML xml) {
+  // @todo #2237:30min Don't kickout graduates from sandbox projects
+  //  Instead of removing the script, we must add a way to enable and
+  //  disable a feature. Add Assume.feature method that will check for
+  //  the feature name in a list of enabled features. Then change claims.xml
+  //  type to `Ping hourly' to add dont_kickout_graduates_from_sandbox to
+  //  tests execution.
   new Assume(project, xml).notPmo()
   new Assume(project, xml).type('Ping hourly')
   Farm farm = binding.variables.farm

--- a/src/test/resources/com/zerocracy/bundles/dont_kickout_graduates_from_sandbox/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_kickout_graduates_from_sandbox/_after.groovy
@@ -17,18 +17,12 @@
 package com.zerocracy.bundles.dont_kickout_graduates_from_sandbox
 
 import com.jcabi.xml.XML
-import com.mongodb.client.model.Filters
 import com.zerocracy.Farm
 import com.zerocracy.Project
-import com.zerocracy.claims.Footprint
 import com.zerocracy.pm.staff.Roles
-import com.zerocracy.pmo.People
 import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
-import org.hamcrest.collection.IsEmptyIterable
 import org.hamcrest.core.IsCollectionContaining
 import org.hamcrest.core.IsEqual
-import org.hamcrest.core.IsNot
 
 def exec(Project project, XML xml) {
   Farm farm = binding.variables.farm

--- a/src/test/resources/com/zerocracy/bundles/dont_kickout_graduates_from_sandbox/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_kickout_graduates_from_sandbox/_after.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016-2019 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.dont_kickout_graduates_from_sandbox
+
+import com.jcabi.xml.XML
+import com.mongodb.client.model.Filters
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.claims.Footprint
+import com.zerocracy.pm.staff.Roles
+import com.zerocracy.pmo.People
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+import org.hamcrest.collection.IsEmptyIterable
+import org.hamcrest.core.IsCollectionContaining
+import org.hamcrest.core.IsEqual
+import org.hamcrest.core.IsNot
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  Roles roles = new Roles(project).bootstrap()
+  MatcherAssert.assertThat(
+    'Must not remove DEV role from paulodamaso',
+    roles.allRoles('paulodamaso'),
+    new IsCollectionContaining<>(
+      new IsEqual('DEV')
+    )
+  )
+  MatcherAssert.assertThat(
+    'Must not remove REV role from paulodamaso',
+    roles.allRoles('paulodamaso'),
+    new IsCollectionContaining<>(
+      new IsEqual('REV')
+    )
+  )
+}

--- a/src/test/resources/com/zerocracy/bundles/dont_kickout_graduates_from_sandbox/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_kickout_graduates_from_sandbox/_after.groovy
@@ -17,7 +17,6 @@
 package com.zerocracy.bundles.dont_kickout_graduates_from_sandbox
 
 import com.jcabi.xml.XML
-import com.zerocracy.Farm
 import com.zerocracy.Project
 import com.zerocracy.pm.staff.Roles
 import org.hamcrest.MatcherAssert

--- a/src/test/resources/com/zerocracy/bundles/dont_kickout_graduates_from_sandbox/_after.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_kickout_graduates_from_sandbox/_after.groovy
@@ -25,7 +25,6 @@ import org.hamcrest.core.IsCollectionContaining
 import org.hamcrest.core.IsEqual
 
 def exec(Project project, XML xml) {
-  Farm farm = binding.variables.farm
   Roles roles = new Roles(project).bootstrap()
   MatcherAssert.assertThat(
     'Must not remove DEV role from paulodamaso',

--- a/src/test/resources/com/zerocracy/bundles/dont_kickout_graduates_from_sandbox/_before.groovy
+++ b/src/test/resources/com/zerocracy/bundles/dont_kickout_graduates_from_sandbox/_before.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016-2019 Zerocracy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.zerocracy.bundles.dont_kickout_graduates_from_sandbox
+
+import com.jcabi.xml.XML
+import com.zerocracy.Farm
+import com.zerocracy.Project
+import com.zerocracy.pmo.Awards
+
+def exec(Project project, XML xml) {
+  Farm farm = binding.variables.farm
+  new Awards(farm, 'paulodamaso').bootstrap().add(
+    project, 2048, 'gh:test/test#1', 'test'
+  )
+}

--- a/src/test/resources/com/zerocracy/bundles/dont_kickout_graduates_from_sandbox/claims.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_kickout_graduates_from_sandbox/claims.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2019 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<claims xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:46Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pm/claims.xsd">
+  <claim id="1">
+    <type>ignored</type>
+    <created>2017-01-15T01:00:00.000Z</created>
+  </claim>
+</claims>

--- a/src/test/resources/com/zerocracy/bundles/dont_kickout_graduates_from_sandbox/roles.xml
+++ b/src/test/resources/com/zerocracy/bundles/dont_kickout_graduates_from_sandbox/roles.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016-2019 Zerocracy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to read
+the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<roles xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updated="2018-09-07T06:54:32Z" version="0.62.5" xsi:noNamespaceSchemaLocation="http://datum.zerocracy.com/0.62.5/xsd/pm/staff/roles.xsd">
+  <person id="yegor256">
+    <role>PO</role>
+    <role>ARC</role>
+    <role>DEV</role>
+  </person>
+  <person id="paulodamaso">
+    <role>DEV</role>
+    <role>REV</role>
+  </person>
+</roles>


### PR DESCRIPTION
For #2237
- removed `kickout_from_sandbox.groovy` stakeholder
- added test that ensured that user is not banned from sandbox projects if graduated